### PR TITLE
feat: Public Navbar Component with active route state

### DIFF
--- a/src/components/landing/Navbar.tsx
+++ b/src/components/landing/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Container, Logo } from "@/components/ui";
 import { cn } from "@/lib/cn";
 
@@ -13,6 +14,12 @@ const navLinks = [
 
 export function Navbar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  const isActiveLink = (href: string) => {
+    if (href === "/") return pathname === "/";
+    return pathname.startsWith(href);
+  };
 
   return (
     <header className="sticky top-0 z-50 bg-white/90 backdrop-blur-md shadow-[var(--shadow-neumorphic-light)]">
@@ -27,9 +34,17 @@ export function Navbar() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="text-text-secondary hover:text-text-primary font-medium transition-colors"
+                className={cn(
+                  "font-medium transition-colors relative",
+                  isActiveLink(link.href)
+                    ? "text-primary"
+                    : "text-text-secondary hover:text-text-primary"
+                )}
               >
                 {link.label}
+                {isActiveLink(link.href) && (
+                  <span className="absolute -bottom-1 left-0 right-0 h-0.5 bg-primary rounded-full" />
+                )}
               </Link>
             ))}
           </div>
@@ -79,7 +94,12 @@ export function Navbar() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="text-text-secondary hover:text-text-primary font-medium py-2"
+                className={cn(
+                  "font-medium py-2 transition-colors",
+                  isActiveLink(link.href)
+                    ? "text-primary"
+                    : "text-text-secondary hover:text-text-primary"
+                )}
                 onClick={() => setIsMobileMenuOpen(false)}
               >
                 {link.label}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Public Navbar Component with active route state

## 🛠️ Issue

- Closes #2

## 📚 Description

- Enhanced public navbar component with active route detection
- Uses Next.js `usePathname` hook to determine current route
- Applies visual feedback for active navigation links
- Maintains neumorphic design system with soft shadows and transitions

## ✅ Changes applied

### Navbar Enhancements
- Added `usePathname` from `next/navigation` for route detection
- Created `isActiveLink` helper function to check if route is active
- Desktop links: Active state shows primary color with underline indicator
- Mobile links: Active state shows primary color text
- Preserved all existing functionality (hamburger menu, responsive design)

### Acceptance Criteria Fulfilled
- [x] Navbar component with logo and navigation links
- [x] Links: Marketplace, FAQ, Help, Login, Register
- [x] Mobile-responsive with hamburger menu
- [x] Active state for current route
- [x] Integrated into Landing page

### Design System
- Neumorphic shadows on header
- Primary color (#149A9B) for active states
- Smooth transitions on hover and active states
- Backdrop blur for sticky header

## 🔍 Evidence/Media (screenshots/videos)

- Build passes successfully with `npm run build`
- TypeScript types verified
- Active state visually distinguishes current route

🤖 Generated with [Claude Code](https://claude.com/claude-code)