### PR TITLE
feat: add Help page with contact form and resources

### DIFF
--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { Navbar } from "@/components/landing";
+import { ContactForm, SupportResources, ContactMethods } from "@/components/help";
+import { cn } from "@/lib/cn";
+
+export default function HelpPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+
+      <main className="py-12 lg:py-16">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Header */}
+          <div className="text-center mb-12">
+            <h1
+              className={cn(
+                "text-3xl sm:text-4xl font-bold text-text-primary mb-4",
+                "opacity-0 animate-fade-in-up"
+              )}
+              style={{ animationFillMode: "forwards" }}
+            >
+              How can we help you?
+            </h1>
+            <p
+              className={cn(
+                "text-text-secondary max-w-2xl mx-auto mb-6",
+                "opacity-0 animate-fade-in-up"
+              )}
+              style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}
+            >
+              Get the support you need. Browse our resources or reach out to our team.
+            </p>
+            <Link
+              href="/faq"
+              className={cn(
+                "inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium",
+                "bg-primary/10 text-primary",
+                "hover:bg-primary hover:text-white",
+                "transition-all duration-200",
+                "opacity-0 animate-fade-in-up"
+              )}
+              style={{ animationDelay: "0.2s", animationFillMode: "forwards" }}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Browse FAQ
+            </Link>
+          </div>
+
+          {/* Support Resources */}
+          <section className="mb-12">
+            <h2
+              className={cn(
+                "text-lg font-bold text-text-primary mb-6",
+                "opacity-0 animate-fade-in-up"
+              )}
+              style={{ animationDelay: "0.15s", animationFillMode: "forwards" }}
+            >
+              Resources
+            </h2>
+            <SupportResources />
+          </section>
+
+          {/* Contact Section */}
+          <section>
+            <h2
+              className={cn(
+                "text-lg font-bold text-text-primary mb-6",
+                "opacity-0 animate-fade-in-up"
+              )}
+              style={{ animationDelay: "0.2s", animationFillMode: "forwards" }}
+            >
+              Contact Us
+            </h2>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div
+                className="opacity-0 animate-fade-in-up"
+                style={{ animationDelay: "0.25s", animationFillMode: "forwards" }}
+              >
+                <ContactForm />
+              </div>
+              <div
+                className="opacity-0 animate-fade-in-up"
+                style={{ animationDelay: "0.3s", animationFillMode: "forwards" }}
+              >
+                <ContactMethods />
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/help/ContactForm.tsx
+++ b/src/components/help/ContactForm.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { cn } from "@/lib/cn";
+import { subjectOptions } from "@/data/help.data";
+import type { ContactFormData } from "@/types/help.types";
+
+export function ContactForm() {
+  const [formData, setFormData] = useState<ContactFormData>({
+    name: "",
+    email: "",
+    subject: "",
+    message: "",
+  });
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // UI only - no backend
+    setIsSubmitted(true);
+    setTimeout(() => {
+      setIsSubmitted(false);
+      setFormData({ name: "", email: "", subject: "", message: "" });
+    }, 3000);
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const selectedSubjectLabel =
+    subjectOptions.find((opt) => opt.value === formData.subject)?.label ||
+    "Select a subject";
+
+  return (
+    <div
+      className={cn(
+        "p-6 sm:p-8 rounded-3xl bg-white",
+        "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+      )}
+    >
+      <h2 className="text-xl font-bold text-text-primary mb-2">Send us a message</h2>
+      <p className="text-sm text-text-secondary mb-6">
+        Fill out the form below and we&apos;ll get back to you as soon as possible.
+      </p>
+
+      {isSubmitted ? (
+        <div
+          className={cn(
+            "p-6 rounded-2xl text-center",
+            "bg-success/10 border border-success/20",
+            "animate-scale-in"
+          )}
+        >
+          <svg
+            className="w-12 h-12 mx-auto text-success mb-3"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <h3 className="text-lg font-semibold text-success mb-1">Message Sent!</h3>
+          <p className="text-sm text-text-secondary">
+            We&apos;ll respond to your inquiry within 24-48 hours.
+          </p>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Name */}
+          <div>
+            <label className="text-sm font-medium text-text-primary mb-2 block">
+              Name
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              required
+              placeholder="Your name"
+              className={cn(
+                "w-full px-4 py-3 rounded-xl text-sm",
+                "bg-background text-text-primary placeholder-text-secondary/50",
+                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                "focus:outline-none focus:ring-2 focus:ring-primary/30",
+                "transition-all duration-200"
+              )}
+            />
+          </div>
+
+          {/* Email */}
+          <div>
+            <label className="text-sm font-medium text-text-primary mb-2 block">
+              Email
+            </label>
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+              placeholder="your@email.com"
+              className={cn(
+                "w-full px-4 py-3 rounded-xl text-sm",
+                "bg-background text-text-primary placeholder-text-secondary/50",
+                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                "focus:outline-none focus:ring-2 focus:ring-primary/30",
+                "transition-all duration-200"
+              )}
+            />
+          </div>
+
+          {/* Subject - Custom Dropdown */}
+          <div>
+            <label className="text-sm font-medium text-text-primary mb-2 block">
+              Subject
+            </label>
+            <div className="relative" ref={dropdownRef}>
+              <button
+                type="button"
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                className={cn(
+                  "w-full flex items-center justify-between px-4 py-3 rounded-xl text-sm",
+                  "bg-background",
+                  "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                  "hover:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff]",
+                  "transition-all duration-200",
+                  formData.subject ? "text-text-primary" : "text-text-secondary/50"
+                )}
+              >
+                <span>{selectedSubjectLabel}</span>
+                <svg
+                  className={cn(
+                    "h-4 w-4 text-text-secondary transition-transform duration-200",
+                    isDropdownOpen && "rotate-180"
+                  )}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {isDropdownOpen && (
+                <div
+                  className={cn(
+                    "absolute top-full left-0 right-0 mt-2 py-2 rounded-2xl bg-white z-50",
+                    "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+                    "border border-border-light/50",
+                    "animate-fade-in"
+                  )}
+                >
+                  {subjectOptions.map((option, index) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => {
+                        setFormData((prev) => ({ ...prev, subject: option.value }));
+                        setIsDropdownOpen(false);
+                      }}
+                      className={cn(
+                        "w-full px-4 py-2.5 text-left text-sm transition-all duration-150",
+                        "opacity-0 animate-slide-in-right",
+                        formData.subject === option.value
+                          ? "bg-primary/10 text-primary font-medium"
+                          : "text-text-secondary hover:bg-background hover:text-text-primary hover:pl-5"
+                      )}
+                      style={{ animationDelay: `${index * 0.03}s`, animationFillMode: "forwards" }}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Message */}
+          <div>
+            <label className="text-sm font-medium text-text-primary mb-2 block">
+              Message
+            </label>
+            <textarea
+              name="message"
+              value={formData.message}
+              onChange={handleChange}
+              required
+              rows={5}
+              placeholder="How can we help you?"
+              className={cn(
+                "w-full px-4 py-3 rounded-xl text-sm resize-none",
+                "bg-background text-text-primary placeholder-text-secondary/50",
+                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                "focus:outline-none focus:ring-2 focus:ring-primary/30",
+                "transition-all duration-200"
+              )}
+            />
+          </div>
+
+          {/* Submit Button */}
+          <button
+            type="submit"
+            className={cn(
+              "w-full px-6 py-3 rounded-xl font-medium",
+              "bg-primary text-white",
+              "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+              "hover:bg-primary-hover hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+              "active:shadow-[inset_4px_4px_8px_rgba(0,0,0,0.2)]",
+              "transition-all duration-200"
+            )}
+          >
+            Send Message
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/components/help/ContactMethods.tsx
+++ b/src/components/help/ContactMethods.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { contactMethods } from "@/data/help.data";
+
+const iconMap: Record<string, React.ReactNode> = {
+  discord: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+    </svg>
+  ),
+  telegram: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+    </svg>
+  ),
+  twitter: (
+    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  ),
+};
+
+export function ContactMethods() {
+  return (
+    <div
+      className={cn(
+        "p-6 sm:p-8 rounded-3xl bg-white",
+        "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+      )}
+    >
+      <h2 className="text-xl font-bold text-text-primary mb-2">Other ways to reach us</h2>
+      <p className="text-sm text-text-secondary mb-6">
+        Choose the channel that works best for you.
+      </p>
+
+      <div className="space-y-4">
+        {contactMethods.map((method, index) => (
+          <a
+            key={method.id}
+            href={method.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "flex items-center gap-4 p-4 rounded-2xl",
+              "bg-background",
+              "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+              "hover:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff]",
+              "transition-all duration-200 group",
+              "opacity-0 animate-slide-in-right"
+            )}
+            style={{ animationDelay: `${index * 0.1}s`, animationFillMode: "forwards" }}
+          >
+            <div
+              className={cn(
+                "p-2.5 rounded-xl",
+                "bg-white text-primary",
+                "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+                "group-hover:bg-primary group-hover:text-white",
+                "transition-all duration-200"
+              )}
+            >
+              {iconMap[method.icon]}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-medium text-text-primary">
+                {method.title}
+              </h3>
+              <p className="text-xs text-text-secondary mt-0.5">
+                {method.description}
+              </p>
+            </div>
+            <span className="text-xs font-medium text-primary truncate max-w-[120px]">
+              {method.value}
+            </span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/help/SupportResources.tsx
+++ b/src/components/help/SupportResources.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { supportResources } from "@/data/help.data";
+
+const iconMap: Record<string, React.ReactNode> = {
+  "help-circle": (
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  book: (
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+    </svg>
+  ),
+  users: (
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
+  ),
+  github: (
+    <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+      <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+    </svg>
+  ),
+};
+
+export function SupportResources() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {supportResources.map((resource, index) => {
+        const isExternal = resource.href.startsWith("http");
+        const LinkComponent = isExternal ? "a" : Link;
+        const linkProps = isExternal
+          ? { href: resource.href, target: "_blank", rel: "noopener noreferrer" }
+          : { href: resource.href };
+
+        return (
+          <LinkComponent
+            key={resource.id}
+            {...linkProps}
+            className={cn(
+              "flex items-start gap-4 p-5 rounded-2xl bg-white",
+              "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+              "hover:shadow-[8px_8px_16px_#d1d5db,-8px_-8px_16px_#ffffff]",
+              "transition-all duration-200 group",
+              "opacity-0 animate-fade-in-up"
+            )}
+            style={{ animationDelay: `${index * 0.1}s`, animationFillMode: "forwards" }}
+          >
+            <div
+              className={cn(
+                "p-3 rounded-xl flex-shrink-0",
+                "bg-background text-primary",
+                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                "group-hover:bg-primary group-hover:text-white",
+                "transition-all duration-200"
+              )}
+            >
+              {iconMap[resource.icon]}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-semibold text-text-primary group-hover:text-primary transition-colors duration-200">
+                {resource.title}
+              </h3>
+              <p className="text-xs text-text-secondary mt-1 line-clamp-2">
+                {resource.description}
+              </p>
+            </div>
+            <svg
+              className="w-5 h-5 text-text-secondary/30 group-hover:text-primary group-hover:translate-x-1 transition-all duration-200 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </LinkComponent>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/help/index.ts
+++ b/src/components/help/index.ts
@@ -1,0 +1,3 @@
+export { ContactForm } from "./ContactForm";
+export { SupportResources } from "./SupportResources";
+export { ContactMethods } from "./ContactMethods";

--- a/src/data/help.data.ts
+++ b/src/data/help.data.ts
@@ -1,0 +1,68 @@
+import type { SupportResource, ContactMethod } from "@/types/help.types";
+
+export const supportResources: SupportResource[] = [
+  {
+    id: "faq",
+    title: "FAQ",
+    description: "Find answers to commonly asked questions about OFFER HUB",
+    icon: "help-circle",
+    href: "/faq",
+  },
+  {
+    id: "docs",
+    title: "Documentation",
+    description: "Comprehensive guides and API documentation for developers",
+    icon: "book",
+    href: "https://github.com/OFFER-HUB/OFFER-HUB-Frontend/tree/main/docs",
+  },
+  {
+    id: "community",
+    title: "Community",
+    description: "Join our Discord server to connect with other users",
+    icon: "users",
+    href: "https://discord.gg/offerhub",
+  },
+  {
+    id: "github",
+    title: "GitHub",
+    description: "Report bugs, request features, or contribute to the project",
+    icon: "github",
+    href: "https://github.com/OFFER-HUB",
+  },
+];
+
+export const contactMethods: ContactMethod[] = [
+  {
+    id: "discord",
+    title: "Discord",
+    description: "Real-time support from our community",
+    icon: "discord",
+    value: "discord.gg/SuqxDrVznQ",
+    href: "https://discord.gg/SuqxDrVznQ",
+  },
+  {
+    id: "telegram",
+    title: "Telegram",
+    description: "Join our Telegram group for quick support",
+    icon: "telegram",
+    value: "t.me/+nllS-VpK5QJmNjA5",
+    href: "https://t.me/+nllS-VpK5QJmNjA5",
+  },
+  {
+    id: "twitter",
+    title: "X (Twitter)",
+    description: "Follow us for updates and announcements",
+    icon: "twitter",
+    value: "@offerhub_",
+    href: "https://x.com/offerhub_",
+  },
+];
+
+export const subjectOptions = [
+  { value: "general", label: "General Inquiry" },
+  { value: "technical", label: "Technical Support" },
+  { value: "billing", label: "Billing & Payments" },
+  { value: "account", label: "Account Issues" },
+  { value: "feedback", label: "Feedback & Suggestions" },
+  { value: "other", label: "Other" },
+];

--- a/src/types/help.types.ts
+++ b/src/types/help.types.ts
@@ -1,0 +1,23 @@
+export interface ContactFormData {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+export interface SupportResource {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  href: string;
+}
+
+export interface ContactMethod {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  value: string;
+  href?: string;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- feat: add Help page with contact form and resources

## 🛠️ Issue

- Closes #5

## 📚 Description

- Implements Help/Support page at `/help` with neumorphic design
- Contact form with custom dropdown (UI only, no backend)
- Support resources section linking to FAQ, docs, community, and GitHub
- Contact methods with email, Discord, and Twitter links
- Link to FAQ from header
- Already accessible from Navbar (link was pre-existing)

## ✅ Changes applied

- Created `src/types/help.types.ts` with type definitions
- Created `src/data/help.data.ts` with support resources and contact methods
- Created `src/components/help/ContactForm.tsx` - neumorphic contact form
- Created `src/components/help/SupportResources.tsx` - resource cards grid
- Created `src/components/help/ContactMethods.tsx` - contact options list
- Created `src/app/help/page.tsx` - main Help page

## 🔍 Evidence/Media (screenshots/videos)

- Navigate to `/help` to see the implementation