### PR TITLE
feat: add create service page for freelancers

### DIFF
--- a/src/app/app/freelancer/services/new/page.tsx
+++ b/src/app/app/freelancer/services/new/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
+import {
+  NEUMORPHIC_CARD,
+  NEUMORPHIC_INPUT,
+  INPUT_ERROR_STYLES,
+  PRIMARY_BUTTON,
+  ICON_BUTTON,
+} from "@/lib/styles";
+import {
+  SERVICE_CATEGORIES,
+  MIN_TITLE_LENGTH,
+  MIN_DESCRIPTION_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MIN_PRICE,
+  MIN_DELIVERY_DAYS,
+  MAX_DELIVERY_DAYS,
+} from "@/data/service.data";
+import type { ServiceFormData, ServiceFormErrors } from "@/types/service.types";
+
+const MOCK_API_DELAY = 1500;
+
+const INITIAL_FORM_DATA: ServiceFormData = {
+  title: "",
+  description: "",
+  category: "",
+  price: 0,
+  deliveryDays: 1,
+};
+
+function validateForm(data: ServiceFormData): ServiceFormErrors {
+  const errors: ServiceFormErrors = {};
+
+  if (!data.title.trim()) {
+    errors.title = "Title is required";
+  } else if (data.title.trim().length < MIN_TITLE_LENGTH) {
+    errors.title = `Title must be at least ${MIN_TITLE_LENGTH} characters`;
+  }
+
+  if (!data.description.trim()) {
+    errors.description = "Description is required";
+  } else if (data.description.trim().length < MIN_DESCRIPTION_LENGTH) {
+    errors.description = `Description must be at least ${MIN_DESCRIPTION_LENGTH} characters`;
+  } else if (data.description.trim().length > MAX_DESCRIPTION_LENGTH) {
+    errors.description = `Description must be less than ${MAX_DESCRIPTION_LENGTH} characters`;
+  }
+
+  if (!data.category) {
+    errors.category = "Please select a category";
+  }
+
+  if (!data.price || data.price < MIN_PRICE) {
+    errors.price = `Price must be at least $${MIN_PRICE}`;
+  }
+
+  if (!data.deliveryDays || data.deliveryDays < MIN_DELIVERY_DAYS) {
+    errors.deliveryDays = `Delivery time must be at least ${MIN_DELIVERY_DAYS} day`;
+  } else if (data.deliveryDays > MAX_DELIVERY_DAYS) {
+    errors.deliveryDays = `Delivery time cannot exceed ${MAX_DELIVERY_DAYS} days`;
+  }
+
+  return errors;
+}
+
+interface FormFieldProps {
+  label: string;
+  required?: boolean;
+  error?: string;
+  children: React.ReactNode;
+}
+
+function FormField({ label, required, error, children }: FormFieldProps): React.JSX.Element {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-text-primary mb-1">
+        {label} {required && <span className="text-error">*</span>}
+      </label>
+      {children}
+      {error && <p className="mt-1 text-xs text-error">{error}</p>}
+    </div>
+  );
+}
+
+export default function CreateServicePage(): React.JSX.Element {
+  const router = useRouter();
+  const [formData, setFormData] = useState<ServiceFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<ServiceFormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ): void {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: name === "price" || name === "deliveryDays" ? Number(value) || 0 : value,
+    }));
+    if (errors[name as keyof ServiceFormErrors]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    const validationErrors = validateForm(formData);
+    setErrors(validationErrors);
+
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    setIsLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, MOCK_API_DELAY));
+    setIsLoading(false);
+    router.push("/app/freelancer/services");
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <div className="flex items-center gap-4">
+        <Link href="/app/freelancer/services" className={ICON_BUTTON}>
+          <Icon path={ICON_PATHS.chevronLeft} size="md" className="text-text-primary" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">Create New Service</h1>
+          <p className="text-text-secondary text-sm">
+            Define your service offering to attract clients
+          </p>
+        </div>
+      </div>
+
+      <div className={NEUMORPHIC_CARD}>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <FormField label="Service Title" required error={errors.title}>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              className={cn(NEUMORPHIC_INPUT, errors.title && INPUT_ERROR_STYLES)}
+              placeholder="e.g., Professional Web Development Services"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              {formData.title.length}/{MIN_TITLE_LENGTH} min characters
+            </p>
+          </FormField>
+
+          <FormField label="Category" required error={errors.category}>
+            <select
+              name="category"
+              value={formData.category}
+              onChange={handleChange}
+              className={cn(
+                NEUMORPHIC_INPUT,
+                "cursor-pointer",
+                errors.category && INPUT_ERROR_STYLES,
+                !formData.category && "text-text-secondary"
+              )}
+            >
+              <option value="">Select a category</option>
+              {SERVICE_CATEGORIES.map((cat) => (
+                <option key={cat.value} value={cat.value}>
+                  {cat.label}
+                </option>
+              ))}
+            </select>
+          </FormField>
+
+          <FormField label="Description" required error={errors.description}>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              rows={5}
+              className={cn(
+                NEUMORPHIC_INPUT,
+                "resize-none",
+                errors.description && INPUT_ERROR_STYLES
+              )}
+              placeholder="Describe your service in detail. What do you offer? What makes your service unique? What will the client receive?"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              {formData.description.length}/{MIN_DESCRIPTION_LENGTH} min, {MAX_DESCRIPTION_LENGTH} max characters
+            </p>
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Price (USD)" required error={errors.price}>
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary">
+                  $
+                </span>
+                <input
+                  type="number"
+                  name="price"
+                  value={formData.price || ""}
+                  onChange={handleChange}
+                  min={MIN_PRICE}
+                  className={cn(
+                    NEUMORPHIC_INPUT,
+                    "pl-8",
+                    errors.price && INPUT_ERROR_STYLES
+                  )}
+                  placeholder="0"
+                />
+              </div>
+            </FormField>
+
+            <FormField label="Delivery Time (days)" required error={errors.deliveryDays}>
+              <div className="relative">
+                <input
+                  type="number"
+                  name="deliveryDays"
+                  value={formData.deliveryDays || ""}
+                  onChange={handleChange}
+                  min={MIN_DELIVERY_DAYS}
+                  max={MAX_DELIVERY_DAYS}
+                  className={cn(
+                    NEUMORPHIC_INPUT,
+                    errors.deliveryDays && INPUT_ERROR_STYLES
+                  )}
+                  placeholder="1"
+                />
+                <span className="absolute right-4 top-1/2 -translate-y-1/2 text-text-secondary text-sm">
+                  {formData.deliveryDays === 1 ? "day" : "days"}
+                </span>
+              </div>
+            </FormField>
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-border-light">
+            <Link
+              href="/app/freelancer/services"
+              className={cn(
+                "px-6 py-3 rounded-xl font-medium",
+                "bg-background text-text-primary",
+                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+                "transition-all duration-200"
+              )}
+            >
+              Cancel
+            </Link>
+            <button type="submit" disabled={isLoading} className={PRIMARY_BUTTON}>
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <LoadingSpinner />
+                  Creating...
+                </span>
+              ) : (
+                "Create Service"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/freelancer/services/page.tsx
+++ b/src/app/app/freelancer/services/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { NEUMORPHIC_CARD, PRIMARY_BUTTON } from "@/lib/styles";
+import { MOCK_SERVICES, SERVICE_CATEGORIES } from "@/data/service.data";
+import type { Service, ServiceStatus } from "@/types/service.types";
+
+const STATUS_STYLES: Record<ServiceStatus, string> = {
+  active: "bg-success/20 text-success",
+  paused: "bg-warning/20 text-warning",
+  archived: "bg-text-secondary/20 text-text-secondary",
+};
+
+const STATUS_LABELS: Record<ServiceStatus, string> = {
+  active: "Active",
+  paused: "Paused",
+  archived: "Archived",
+};
+
+function getCategoryLabel(value: string): string {
+  return SERVICE_CATEGORIES.find((c) => c.value === value)?.label || value;
+}
+
+interface ServiceCardProps {
+  service: Service;
+}
+
+function ServiceCard({ service }: ServiceCardProps): React.JSX.Element {
+  return (
+    <div className={cn(NEUMORPHIC_CARD, "p-4")}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="font-semibold text-text-primary truncate">{service.title}</h3>
+            <span
+              className={cn(
+                "px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0",
+                STATUS_STYLES[service.status]
+              )}
+            >
+              {STATUS_LABELS[service.status]}
+            </span>
+          </div>
+          <p className="text-sm text-text-secondary mb-2">{getCategoryLabel(service.category)}</p>
+          <p className="text-sm text-text-secondary line-clamp-2">{service.description}</p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between mt-4 pt-3 border-t border-border-light">
+        <div className="flex items-center gap-4 text-sm">
+          <span className="text-text-primary font-semibold">${service.price}</span>
+          <span className="text-text-secondary flex items-center gap-1">
+            <Icon path={ICON_PATHS.clock} size="sm" />
+            {service.deliveryDays} {service.deliveryDays === 1 ? "day" : "days"}
+          </span>
+          <span className="text-text-secondary flex items-center gap-1">
+            <Icon path={ICON_PATHS.star} size="sm" className="text-warning" />
+            {service.rating}
+          </span>
+          <span className="text-text-secondary">{service.orders} orders</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className={cn(
+              "p-2 rounded-lg",
+              "text-text-secondary hover:text-text-primary hover:bg-background",
+              "transition-colors cursor-pointer"
+            )}
+            title="Edit"
+          >
+            <Icon path={ICON_PATHS.edit} size="sm" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ServicesPage(): React.JSX.Element {
+  const [services] = useState<Service[]>(MOCK_SERVICES);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">My Services</h1>
+          <p className="text-text-secondary text-sm">
+            Manage your service offerings
+          </p>
+        </div>
+        <Link href="/app/freelancer/services/new" className={cn(PRIMARY_BUTTON, "flex items-center gap-2")}>
+          <Icon path={ICON_PATHS.plus} size="sm" />
+          Create Service
+        </Link>
+      </div>
+
+      {services.length === 0 ? (
+        <div className={cn(NEUMORPHIC_CARD, "text-center py-12")}>
+          <Icon
+            path={ICON_PATHS.briefcase}
+            size="xl"
+            className="text-gray-300 mx-auto mb-4"
+          />
+          <h3 className="text-lg font-medium text-text-primary mb-2">
+            No services yet
+          </h3>
+          <p className="text-text-secondary mb-4">
+            Create your first service to start attracting clients.
+          </p>
+          <Link
+            href="/app/freelancer/services/new"
+            className={cn(PRIMARY_BUTTON, "inline-flex items-center gap-2")}
+          >
+            <Icon path={ICON_PATHS.plus} size="sm" />
+            Create Your First Service
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {services.map((service) => (
+            <ServiceCard key={service.id} service={service} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/service.data.ts
+++ b/src/data/service.data.ts
@@ -1,0 +1,62 @@
+import type { Service, ServiceCategory } from "@/types/service.types";
+
+export const MIN_TITLE_LENGTH = 10;
+export const MIN_DESCRIPTION_LENGTH = 50;
+export const MAX_DESCRIPTION_LENGTH = 2000;
+export const MIN_PRICE = 5;
+export const MIN_DELIVERY_DAYS = 1;
+export const MAX_DELIVERY_DAYS = 90;
+
+export const SERVICE_CATEGORIES: { value: ServiceCategory; label: string }[] = [
+  { value: "web-development", label: "Web Development" },
+  { value: "mobile-development", label: "Mobile Development" },
+  { value: "design", label: "Design & Creative" },
+  { value: "writing", label: "Writing & Translation" },
+  { value: "marketing", label: "Marketing & Sales" },
+  { value: "video", label: "Video & Animation" },
+  { value: "music", label: "Music & Audio" },
+  { value: "data", label: "Data & Analytics" },
+  { value: "other", label: "Other" },
+];
+
+export const MOCK_SERVICES: Service[] = [
+  {
+    id: "1",
+    title: "Professional React & Next.js Web Development",
+    description:
+      "I will build modern, responsive web applications using React and Next.js with TypeScript. Includes SEO optimization, performance tuning, and clean code architecture.",
+    category: "web-development",
+    price: 150,
+    deliveryDays: 7,
+    status: "active",
+    createdAt: "2024-01-15",
+    orders: 24,
+    rating: 4.9,
+  },
+  {
+    id: "2",
+    title: "Custom Logo Design with Unlimited Revisions",
+    description:
+      "Get a unique, professional logo design for your brand. Package includes multiple concepts, unlimited revisions, and all source files in various formats.",
+    category: "design",
+    price: 75,
+    deliveryDays: 3,
+    status: "active",
+    createdAt: "2024-02-20",
+    orders: 56,
+    rating: 4.8,
+  },
+  {
+    id: "3",
+    title: "SEO-Optimized Blog Articles & Content Writing",
+    description:
+      "Professional content writing services for blogs, websites, and marketing materials. Well-researched, engaging content optimized for search engines.",
+    category: "writing",
+    price: 50,
+    deliveryDays: 2,
+    status: "active",
+    createdAt: "2024-03-10",
+    orders: 89,
+    rating: 5.0,
+  },
+];

--- a/src/stores/mode-store.ts
+++ b/src/stores/mode-store.ts
@@ -33,6 +33,7 @@ export interface NavigationItem {
 
 const FREELANCER_NAV_ITEMS: NavigationItem[] = [
   { href: "/app/freelancer/dashboard", label: "Dashboard", icon: ICON_PATHS.home },
+  { href: "/app/freelancer/services", label: "My Services", icon: ICON_PATHS.briefcase },
   { href: "/app/projects", label: "Find Projects", icon: ICON_PATHS.search },
   { href: "/app/proposals", label: "My Proposals", icon: ICON_PATHS.document },
   { href: "/app/earnings", label: "Earnings", icon: ICON_PATHS.currency },

--- a/src/types/service.types.ts
+++ b/src/types/service.types.ts
@@ -1,0 +1,41 @@
+export type ServiceStatus = "active" | "paused" | "archived";
+
+export type ServiceCategory =
+  | "web-development"
+  | "mobile-development"
+  | "design"
+  | "writing"
+  | "marketing"
+  | "video"
+  | "music"
+  | "data"
+  | "other";
+
+export interface ServiceFormData {
+  title: string;
+  description: string;
+  category: ServiceCategory | "";
+  price: number;
+  deliveryDays: number;
+}
+
+export interface ServiceFormErrors {
+  title?: string;
+  description?: string;
+  category?: string;
+  price?: string;
+  deliveryDays?: string;
+}
+
+export interface Service {
+  id: string;
+  title: string;
+  description: string;
+  category: ServiceCategory;
+  price: number;
+  deliveryDays: number;
+  status: ServiceStatus;
+  createdAt: string;
+  orders: number;
+  rating: number;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Add create service page for freelancers

## 🛠️ Issue

- Closes #25

## 📚 Description

- Implement a service creation feature that enables freelancers to publish new service offerings within the platform

## ✅ Changes applied

- Add service creation page at `/app/freelancer/services/new` with form validation
- Implement form fields: title, description, price, category, and delivery time
- Add form validation with user-facing error messages
- Create services list page at `/app/freelancer/services` for redirect after creation
- Add "My Services" navigation link in freelancer sidebar
- Create service types (`service.types.ts`) and mock data (`service.data.ts`)
- Submit button with mock success handling and redirect to services list

## 🔍 Evidence/Media (screenshots/videos)

- Service creation form with all required fields
- Form validation error messages
- Services list page with service cards
- Navigation from Freelancer Dashboard → Create Service → Services List