### PR TITLE
feat: add service detail page with orders and actions

### DIFF
--- a/src/app/app/freelancer/services/[id]/page.tsx
+++ b/src/app/app/freelancer/services/[id]/page.tsx
@@ -1,147 +1,398 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { use, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 import { NEUMORPHIC_CARD, PRIMARY_BUTTON, ICON_BUTTON } from "@/lib/styles";
-import { MOCK_SERVICES, SERVICE_CATEGORIES } from "@/data/service.data";
-import type { Service } from "@/types/service.types";
+import {
+  MOCK_SERVICES,
+  SERVICE_CATEGORIES,
+  ORDER_STATUS_LABELS,
+  ORDER_STATUS_COLORS,
+  getOrdersByServiceId,
+} from "@/data/service.data";
+import type { Service, ServiceOrder, ServiceStatus } from "@/types/service.types";
 
 interface PageProps {
-    params: Promise<{ id: string }>;
+  params: Promise<{ id: string }>;
 }
 
+const STATUS_STYLES: Record<ServiceStatus, string> = {
+  active: "bg-success/20 text-success",
+  paused: "bg-warning/20 text-warning",
+  archived: "bg-text-secondary/20 text-text-secondary",
+};
+
+const STATUS_LABELS: Record<ServiceStatus, string> = {
+  active: "Active",
+  paused: "Paused",
+  archived: "Archived",
+};
+
 function getCategoryLabel(value: string): string {
-    return SERVICE_CATEGORIES.find((c) => c.value === value)?.label || value;
+  return SERVICE_CATEGORIES.find((c) => c.value === value)?.label || value;
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface OrderCardProps {
+  order: ServiceOrder;
+}
+
+function OrderCard({ order }: OrderCardProps): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between p-4 rounded-xl bg-background">
+      <div className="flex items-center gap-3">
+        <div
+          className={cn(
+            "w-10 h-10 rounded-full flex items-center justify-center",
+            "bg-primary text-white font-semibold text-sm"
+          )}
+        >
+          {order.clientAvatar}
+        </div>
+        <div>
+          <p className="font-medium text-text-primary">{order.clientName}</p>
+          <p className="text-sm text-text-secondary">
+            Ordered {formatDate(order.orderedAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="text-right hidden sm:block">
+          <p className="font-semibold text-text-primary">${order.price}</p>
+          <p className="text-xs text-text-secondary">
+            Due {formatDate(order.deliveryDate)}
+          </p>
+        </div>
+
+        <span
+          className={cn(
+            "px-3 py-1 rounded-full text-xs font-medium",
+            ORDER_STATUS_COLORS[order.status]
+          )}
+        >
+          {ORDER_STATUS_LABELS[order.status]}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <Link
+            href={`/app/chat?client=${order.id}`}
+            className={cn(
+              "p-2 rounded-lg",
+              "text-text-secondary hover:text-primary hover:bg-primary/10",
+              "transition-colors cursor-pointer"
+            )}
+            title="Chat with client"
+          >
+            <Icon path={ICON_PATHS.chat} size="sm" />
+          </Link>
+
+          {order.hasDispute ? (
+            <Link
+              href={`/app/disputes?order=${order.id}`}
+              className={cn(
+                "p-2 rounded-lg",
+                "text-error hover:bg-error/10",
+                "transition-colors cursor-pointer"
+              )}
+              title="View dispute"
+            >
+              <Icon path={ICON_PATHS.flag} size="sm" />
+            </Link>
+          ) : (
+            <Link
+              href={`/app/disputes/new?order=${order.id}`}
+              className={cn(
+                "p-2 rounded-lg",
+                "text-text-secondary hover:text-warning hover:bg-warning/10",
+                "transition-colors cursor-pointer"
+              )}
+              title="Open dispute"
+            >
+              <Icon path={ICON_PATHS.flag} size="sm" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ServiceActionsProps {
+  service: Service;
+  onStatusChange: (status: ServiceStatus) => void;
+  onDelete: () => void;
+}
+
+function ServiceActions({ service, onStatusChange, onDelete }: ServiceActionsProps): React.JSX.Element {
+  return (
+    <div className={NEUMORPHIC_CARD}>
+      <h2 className="text-lg font-semibold text-text-primary mb-4">Actions</h2>
+      <div className="space-y-3">
+        <Link
+          href={`/app/freelancer/services/${service.id}/edit`}
+          className={cn(
+            "flex items-center gap-3 w-full px-4 py-3 rounded-xl",
+            "bg-background text-text-primary",
+            "hover:bg-gray-100 transition-colors cursor-pointer"
+          )}
+        >
+          <Icon path={ICON_PATHS.edit} size="md" />
+          <span className="font-medium">Edit Service</span>
+        </Link>
+
+        {service.status === "active" ? (
+          <button
+            type="button"
+            onClick={() => onStatusChange("paused")}
+            className={cn(
+              "flex items-center gap-3 w-full px-4 py-3 rounded-xl",
+              "bg-warning/10 text-warning",
+              "hover:bg-warning/20 transition-colors cursor-pointer"
+            )}
+          >
+            <Icon path={ICON_PATHS.clock} size="md" />
+            <span className="font-medium">Pause Service</span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onStatusChange("active")}
+            className={cn(
+              "flex items-center gap-3 w-full px-4 py-3 rounded-xl",
+              "bg-success/10 text-success",
+              "hover:bg-success/20 transition-colors cursor-pointer"
+            )}
+          >
+            <Icon path={ICON_PATHS.check} size="md" />
+            <span className="font-medium">Activate Service</span>
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={onDelete}
+          className={cn(
+            "flex items-center gap-3 w-full px-4 py-3 rounded-xl",
+            "bg-error/10 text-error",
+            "hover:bg-error/20 transition-colors cursor-pointer"
+          )}
+        >
+          <Icon path={ICON_PATHS.trash} size="md" />
+          <span className="font-medium">Delete Service</span>
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Element {
-    // Unwrap params using React.use()
-    const { id } = use(params);
+  const { id } = use(params);
+  const router = useRouter();
 
-    const router = useRouter();
-    const [service, setService] = useState<Service | null>(null);
+  const initialService = MOCK_SERVICES.find((s) => s.id === id);
+  const [service, setService] = useState<Service | undefined>(initialService);
+  const orders = getOrdersByServiceId(id);
 
-    useEffect(() => {
-        // Simulate fetching
-        const found = MOCK_SERVICES.find((s) => s.id === id);
-        if (found) {
-            setService(found);
-        }
-    }, [id]);
-
-    if (!service) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-[50vh] text-text-secondary">
-                <Icon path={ICON_PATHS.briefcase} size="xl" className="mb-4 opacity-50" />
-                <p>Service not found</p>
-                <Link href="/app/freelancer/services" className="text-primary mt-2 hover:underline">
-                    Back to Services
-                </Link>
-            </div>
-        );
+  function handleStatusChange(newStatus: ServiceStatus): void {
+    if (service) {
+      setService({ ...service, status: newStatus });
     }
+  }
 
+  function handleDelete(): void {
+    if (confirm("Are you sure you want to delete this service? This action cannot be undone.")) {
+      router.push("/app/freelancer/services");
+    }
+  }
+
+  if (!service) {
     return (
-        <div className="max-w-4xl mx-auto space-y-6">
-            {/* Header */}
-            <div className="flex items-center gap-4">
-                <Link href="/app/freelancer/services" className={ICON_BUTTON}>
-                    <Icon path={ICON_PATHS.chevronLeft} size="md" className="text-text-primary" />
-                </Link>
-                <div className="flex-1">
-                    <h1 className="text-2xl font-bold text-text-primary">Service Details</h1>
-                    <p className="text-text-secondary text-sm">
-                        View and manage your service
-                    </p>
-                </div>
-                <div className="flex items-center gap-3">
-                    <button
-                        type="button"
-                        className={cn(
-                            "p-2 rounded-xl border border-error/50 text-error hover:bg-error/10 transition-colors"
-                        )}
-                        onClick={() => {
-                            if (confirm("Are you sure you want to delete this service?")) {
-                                router.push("/app/freelancer/services");
-                            }
-                        }}
-                    >
-                        <Icon path={ICON_PATHS.trash} size="md" />
-                    </button>
-                    <Link
-                        href={`/app/freelancer/services/${service.id}/edit`}
-                        className={cn(PRIMARY_BUTTON, "flex items-center gap-2")}
-                    >
-                        <Icon path={ICON_PATHS.edit} size="sm" />
-                        Edit Service
-                    </Link>
-                </div>
-            </div>
-
-            {/* Main Content */}
-            <div className={cn(NEUMORPHIC_CARD, "p-8 space-y-8")}>
-                {/* Title & Status */}
-                <div className="flex items-start justify-between gap-4">
-                    <div>
-                        <h2 className="text-2xl font-bold text-text-primary mb-2">{service.title}</h2>
-                        <div className="flex items-center gap-3">
-                            <span className="px-3 py-1 rounded-full text-sm font-medium bg-secondary text-text-secondary border border-border-light">
-                                {getCategoryLabel(service.category)}
-                            </span>
-                            <span
-                                className={cn(
-                                    "px-3 py-1 rounded-full text-sm font-medium",
-                                    service.status === "active" ? "bg-success/20 text-success" :
-                                        service.status === "paused" ? "bg-warning/20 text-warning" :
-                                            "bg-text-secondary/20 text-text-secondary"
-                                )}
-                            >
-                                {service.status.charAt(0).toUpperCase() + service.status.slice(1)}
-                            </span>
-                        </div>
-                    </div>
-                    <div className="text-right">
-                        <div className="text-3xl font-bold text-primary">${service.price}</div>
-                        <div className="text-text-secondary text-sm">per order</div>
-                    </div>
-                </div>
-
-                {/* Stats */}
-                <div className="grid grid-cols-3 gap-4 border-y border-border-light py-6">
-                    <div className="flex flex-col items-center justify-center border-r border-border-light">
-                        <div className="flex items-center gap-2 text-text-primary font-bold text-xl">
-                            <Icon path={ICON_PATHS.star} size="md" className="text-warning" />
-                            {service.rating}
-                        </div>
-                        <div className="text-xs text-text-secondary uppercase tracking-wider font-semibold mt-1">Rating</div>
-                    </div>
-                    <div className="flex flex-col items-center justify-center border-r border-border-light">
-                        <div className="flex items-center gap-2 text-text-primary font-bold text-xl">
-                            <Icon path={ICON_PATHS.briefcase} size="md" className="text-primary" />
-                            {service.orders}
-                        </div>
-                        <div className="text-xs text-text-secondary uppercase tracking-wider font-semibold mt-1">Orders</div>
-                    </div>
-                    <div className="flex flex-col items-center justify-center">
-                        <div className="flex items-center gap-2 text-text-primary font-bold text-xl">
-                            <Icon path={ICON_PATHS.clock} size="md" className="text-text-secondary" />
-                            {service.deliveryDays}d
-                        </div>
-                        <div className="text-xs text-text-secondary uppercase tracking-wider font-semibold mt-1">Delivery</div>
-                    </div>
-                </div>
-
-                {/* Description */}
-                <div>
-                    <h3 className="text-lg font-bold text-text-primary mb-3">Description</h3>
-                    <p className="text-text-secondary leading-relaxed whitespace-pre-wrap">
-                        {service.description}
-                    </p>
-                </div>
-            </div>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className={cn(NEUMORPHIC_CARD, "text-center max-w-md")}>
+          <div
+            className={cn(
+              "w-20 h-20 mx-auto mb-4 rounded-full flex items-center justify-center",
+              "bg-background",
+              "shadow-[inset_4px_4px_8px_#d1d5db,inset_-4px_-4px_8px_#ffffff]"
+            )}
+          >
+            <Icon path={ICON_PATHS.briefcase} size="xl" className="text-text-secondary" />
+          </div>
+          <h2 className="text-xl font-bold text-text-primary mb-2">
+            Service not found
+          </h2>
+          <p className="text-text-secondary mb-4">
+            The service you are looking for does not exist or has been removed.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.push("/app/freelancer/services")}
+            className={PRIMARY_BUTTON}
+          >
+            Back to Services
+          </button>
         </div>
+      </div>
     );
+  }
+
+  const activeOrders = orders.filter((o) => o.status === "in_progress" || o.status === "pending");
+  const completedOrders = orders.filter((o) => o.status === "completed" || o.status === "delivered");
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <Link href="/app/freelancer/services" className={ICON_BUTTON}>
+          <Icon path={ICON_PATHS.chevronLeft} size="md" className="text-text-primary" />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h1 className="text-2xl font-bold text-text-primary truncate">
+              {service.title}
+            </h1>
+            <span
+              className={cn(
+                "px-3 py-1 rounded-lg text-sm font-medium flex-shrink-0",
+                STATUS_STYLES[service.status]
+              )}
+            >
+              {STATUS_LABELS[service.status]}
+            </span>
+          </div>
+          <p className="text-text-secondary mt-1">
+            {getCategoryLabel(service.category)} • Created {formatDate(service.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+        <div className="xl:col-span-2 space-y-4">
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Service Details
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <p className="text-text-secondary text-sm mb-1">Description</p>
+                <p className="text-text-primary whitespace-pre-wrap">{service.description}</p>
+              </div>
+
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 pt-4 border-t border-border-light">
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Price</p>
+                  <p className="text-xl font-bold text-primary">${service.price}</p>
+                </div>
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Delivery</p>
+                  <p className="text-xl font-bold text-text-primary">
+                    {service.deliveryDays} {service.deliveryDays === 1 ? "day" : "days"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Total Orders</p>
+                  <p className="text-xl font-bold text-text-primary">{service.orders}</p>
+                </div>
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Rating</p>
+                  <p className="text-xl font-bold text-text-primary flex items-center gap-1">
+                    <Icon path={ICON_PATHS.star} size="sm" className="text-warning" />
+                    {service.rating}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {activeOrders.length > 0 && (
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Active Orders ({activeOrders.length})
+              </h2>
+              <div className="space-y-3">
+                {activeOrders.map((order) => (
+                  <OrderCard key={order.id} order={order} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {completedOrders.length > 0 && (
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Recent Orders ({completedOrders.length})
+              </h2>
+              <div className="space-y-3">
+                {completedOrders.map((order) => (
+                  <OrderCard key={order.id} order={order} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {orders.length === 0 && (
+            <div className={cn(NEUMORPHIC_CARD, "text-center py-8")}>
+              <Icon
+                path={ICON_PATHS.users}
+                size="xl"
+                className="text-gray-300 mx-auto mb-3"
+              />
+              <h3 className="text-lg font-medium text-text-primary mb-1">
+                No orders yet
+              </h3>
+              <p className="text-text-secondary text-sm">
+                Orders from clients will appear here once they start coming in.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <ServiceActions
+            service={service}
+            onStatusChange={handleStatusChange}
+            onDelete={handleDelete}
+          />
+
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Statistics
+            </h2>
+            <div className="space-y-3">
+              <div className="flex justify-between items-center">
+                <span className="text-text-secondary">Total Earnings</span>
+                <span className="font-semibold text-text-primary">
+                  ${service.orders * service.price}
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-text-secondary">Active Orders</span>
+                <span className="font-semibold text-text-primary">
+                  {activeOrders.length}
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-text-secondary">Completion Rate</span>
+                <span className="font-semibold text-success">98%</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-text-secondary">Avg. Response Time</span>
+                <span className="font-semibold text-text-primary">2 hours</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/data/service.data.ts
+++ b/src/data/service.data.ts
@@ -1,4 +1,4 @@
-import type { Service, ServiceCategory } from "@/types/service.types";
+import type { Service, ServiceCategory, ServiceOrder, OrderStatus } from "@/types/service.types";
 
 export const MIN_TITLE_LENGTH = 10;
 export const MIN_DESCRIPTION_LENGTH = 50;
@@ -60,3 +60,85 @@ export const MOCK_SERVICES: Service[] = [
     rating: 5.0,
   },
 ];
+
+export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  pending: "Pending",
+  in_progress: "In Progress",
+  delivered: "Delivered",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
+export const ORDER_STATUS_COLORS: Record<OrderStatus, string> = {
+  pending: "bg-warning/20 text-warning",
+  in_progress: "bg-primary/20 text-primary",
+  delivered: "bg-accent/20 text-accent",
+  completed: "bg-success/20 text-success",
+  cancelled: "bg-error/20 text-error",
+};
+
+export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
+  {
+    id: "ord-1",
+    serviceId: "1",
+    clientName: "Sarah Johnson",
+    clientAvatar: "SJ",
+    status: "in_progress",
+    price: 150,
+    orderedAt: "2024-12-01",
+    deliveryDate: "2024-12-08",
+    hasDispute: false,
+  },
+  {
+    id: "ord-2",
+    serviceId: "1",
+    clientName: "Michael Chen",
+    clientAvatar: "MC",
+    status: "pending",
+    price: 150,
+    orderedAt: "2024-12-10",
+    deliveryDate: "2024-12-17",
+    hasDispute: false,
+  },
+  {
+    id: "ord-3",
+    serviceId: "1",
+    clientName: "Emily Rodriguez",
+    clientAvatar: "ER",
+    status: "completed",
+    price: 150,
+    orderedAt: "2024-11-15",
+    deliveryDate: "2024-11-22",
+    hasDispute: false,
+  },
+  {
+    id: "ord-4",
+    serviceId: "1",
+    clientName: "David Kim",
+    clientAvatar: "DK",
+    status: "delivered",
+    price: 150,
+    orderedAt: "2024-11-28",
+    deliveryDate: "2024-12-05",
+    hasDispute: true,
+  },
+  {
+    id: "ord-5",
+    serviceId: "2",
+    clientName: "Lisa Thompson",
+    clientAvatar: "LT",
+    status: "in_progress",
+    price: 75,
+    orderedAt: "2024-12-08",
+    deliveryDate: "2024-12-11",
+    hasDispute: false,
+  },
+];
+
+export function getServiceById(id: string): Service | undefined {
+  return MOCK_SERVICES.find((s) => s.id === id);
+}
+
+export function getOrdersByServiceId(serviceId: string): ServiceOrder[] {
+  return MOCK_SERVICE_ORDERS.filter((o) => o.serviceId === serviceId);
+}

--- a/src/types/service.types.ts
+++ b/src/types/service.types.ts
@@ -39,3 +39,17 @@ export interface Service {
   orders: number;
   rating: number;
 }
+
+export type OrderStatus = "pending" | "in_progress" | "delivered" | "completed" | "cancelled";
+
+export interface ServiceOrder {
+  id: string;
+  serviceId: string;
+  clientName: string;
+  clientAvatar: string;
+  status: OrderStatus;
+  price: number;
+  orderedAt: string;
+  deliveryDate: string;
+  hasDispute: boolean;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Add service detail page with orders and actions

## 🛠️ Issue

- Closes #27

## 📚 Description

- Implement the service detail page at `/app/freelancer/services/[id]` for freelancers to view and manage individual services
- Display complete service information with client orders and management actions

## ✅ Changes applied

- Add `OrderStatus` and `ServiceOrder` types in `service.types.ts`
- Add mock service orders data with status labels and colors in `service.data.ts`
- Add helper functions `getServiceById()` and `getOrdersByServiceId()`
- Implement service detail page with:
  - Service information display (title, description, category, price, delivery time, rating)
  - Active orders section (pending and in progress)
  - Completed orders section (delivered and completed)
  - Action buttons: Edit Service, Pause/Activate toggle, Delete Service
  - Chat and dispute navigation links per order
  - Statistics panel (total earnings, active orders, completion rate, response time)
  - "Service not found" state for invalid IDs

## 🔍 Evidence/Media (screenshots/videos)

- Navigate to `/app/freelancer/services` and click on any service to view the detail page