### PR TITLE
feat: add contact client action and chat navigation for freelancers

### DIFF
--- a/src/app/app/freelancer/services/[id]/page.tsx
+++ b/src/app/app/freelancer/services/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   ORDER_STATUS_COLORS,
   getOrdersByServiceId,
 } from "@/data/service.data";
+import { getChatIdByOrderId } from "@/data/chat.data";
 import type { Service, ServiceOrder, ServiceStatus } from "@/types/service.types";
 
 interface PageProps {
@@ -86,7 +87,7 @@ function OrderCard({ order }: OrderCardProps): React.JSX.Element {
 
         <div className="flex items-center gap-1">
           <Link
-            href={`/app/chat?client=${order.id}`}
+            href={`/app/chat/${getChatIdByOrderId(order.id)}`}
             className={cn(
               "p-2 rounded-lg",
               "text-text-secondary hover:text-primary hover:bg-primary/10",

--- a/src/components/marketplace/PopularOfferCard.tsx
+++ b/src/components/marketplace/PopularOfferCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import type { Offer } from "@/types/marketplace.types";
 import { cn } from "@/lib/cn";
+import { getChatIdByOfferId } from "@/data/chat.data";
 
 interface PopularOfferCardProps {
   offer: Offer;
@@ -10,6 +12,14 @@ interface PopularOfferCardProps {
 }
 
 export function PopularOfferCard({ offer, onClick }: PopularOfferCardProps) {
+  const router = useRouter();
+
+  function handleApply(e: React.MouseEvent): void {
+    e.stopPropagation();
+    const chatId = getChatIdByOfferId(offer.id);
+    router.push(`/app/chat/${chatId}?offer=${offer.id}`);
+  }
+
   return (
     <div
       onClick={onClick}
@@ -66,13 +76,27 @@ export function PopularOfferCard({ offer, onClick }: PopularOfferCardProps) {
       </div>
 
       {/* Footer */}
-      <div className="flex items-center gap-2 text-xs text-text-secondary pt-2 border-t border-border-light">
-        <span className="inline-flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-primary" />
-          {offer.postedAt}
-        </span>
-        <span className="text-text-secondary/40">-</span>
-        <span>{offer.applicants} Applied</span>
+      <div className="flex items-center justify-between pt-2 border-t border-border-light">
+        <div className="flex items-center gap-2 text-xs text-text-secondary">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-full bg-primary" />
+            {offer.postedAt}
+          </span>
+          <span className="text-text-secondary/40">-</span>
+          <span>{offer.applicants} Applied</span>
+        </div>
+        <button
+          onClick={handleApply}
+          className={cn(
+            "px-3 py-1.5 rounded-lg text-xs font-medium",
+            "bg-primary text-white",
+            "hover:bg-primary-hover transition-colors",
+            "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+            "hover:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.1)]"
+          )}
+        >
+          Apply
+        </button>
       </div>
     </div>
   );

--- a/src/data/chat.data.ts
+++ b/src/data/chat.data.ts
@@ -203,3 +203,33 @@ export function getConversationById(id: string): Conversation | undefined {
 export function getChatThreadById(id: string): ChatThread | undefined {
   return MOCK_CHAT_THREADS[id];
 }
+
+const DEFAULT_CHAT_ID = "1";
+
+const OFFER_TO_CHAT: Record<string, string> = {
+  "offer-1": "1",
+  "offer-2": "2",
+  "offer-3": "3",
+  "offer-4": "4",
+};
+
+const ORDER_TO_CHAT: Record<string, string> = {
+  "ord-1": "1",
+  "ord-2": "2",
+  "ord-3": "3",
+  "ord-4": "4",
+  "ord-5": "5",
+};
+
+export function getOrCreateChatByClientId(clientId: string): string {
+  const conversation = MOCK_CONVERSATIONS.find((c) => c.participant.id === clientId);
+  return conversation?.id ?? DEFAULT_CHAT_ID;
+}
+
+export function getChatIdByOfferId(offerId: string): string {
+  return OFFER_TO_CHAT[offerId] ?? DEFAULT_CHAT_ID;
+}
+
+export function getChatIdByOrderId(orderId: string): string {
+  return ORDER_TO_CHAT[orderId] ?? DEFAULT_CHAT_ID;
+}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Add contact client action and chat navigation for freelancers

## 🛠️ Issue

- Closes #28
- Closes #29

## 📚 Description

- Implement contact client functionality enabling freelancers to respond to marketplace offers
- Integrate existing chat system into freelancer mode workflows

## ✅ Changes applied

- Add "Apply" button on marketplace offer cards (`PopularOfferCard.tsx`)
- Clicking the Apply button navigates to chat with the client
- Add helper functions in `chat.data.ts`:
  - `getOrCreateChatByClientId()` - Get or create chat by client ID
  - `getChatIdByOfferId()` - Map offer ID to chat ID
  - `getChatIdByOrderId()` - Map order ID to chat ID
- Update service panel to link directly to relevant chats using `getChatIdByOrderId()`
- Chat is already accessible via Freelancer Dashboard menu (`/app/chat`)
- Mode context is preserved when navigating to chat (no mode switching)

## 🔍 Evidence/Media (screenshots/videos)

- Navigate to `/marketplace` and click "Apply" on any offer card
- Navigate to `/app/freelancer/services/1` and click chat icon on any order