### PR TITLE
feat: add freelancer disputes management (Issues #30 & #31)

### DIFF
--- a/src/app/app/freelancer/disputes/[id]/page.tsx
+++ b/src/app/app/freelancer/disputes/[id]/page.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { useModeStore } from "@/stores/mode-store";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import {
+  NEUMORPHIC_CARD,
+  NEUMORPHIC_INSET,
+  ICON_BUTTON,
+  PRIMARY_BUTTON,
+} from "@/lib/styles";
+import { getFreelancerDisputeById } from "@/data/dispute.data";
+import {
+  DISPUTE_REASON_LABELS,
+  DISPUTE_STATUS_LABELS,
+} from "@/types/dispute.types";
+import type { Dispute, DisputeStatus, DisputeComment } from "@/types/dispute.types";
+
+const STATUS_COLORS: Record<DisputeStatus, string> = {
+  open: "bg-warning/20 text-warning",
+  under_review: "bg-primary/20 text-primary",
+  resolved: "bg-success/20 text-success",
+  closed: "bg-text-secondary/20 text-text-secondary",
+};
+
+const EVENT_ICONS: Record<string, string> = {
+  created: ICON_PATHS.plus,
+  evidence_added: ICON_PATHS.file,
+  status_changed: ICON_PATHS.flag,
+  comment_added: ICON_PATHS.chat,
+  resolved: ICON_PATHS.check,
+};
+
+const COMMENT_ROLE_COLORS: Record<DisputeComment["authorRole"], string> = {
+  client: "bg-secondary/10 border-secondary/20",
+  freelancer: "bg-primary/10 border-primary/20",
+  admin: "bg-warning/10 border-warning/20",
+};
+
+const COMMENT_ROLE_LABELS: Record<DisputeComment["authorRole"], string> = {
+  client: "Client",
+  freelancer: "Freelancer",
+  admin: "Support",
+};
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface InfoRowProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function InfoRow({ label, children }: InfoRowProps): React.JSX.Element {
+  return (
+    <div className="flex justify-between">
+      <span className="text-text-secondary text-sm">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export default function FreelancerDisputeDetailPage(): React.JSX.Element {
+  const params = useParams();
+  const router = useRouter();
+  const { setMode } = useModeStore();
+  const [dispute, setDispute] = useState<Dispute | null>(null);
+  const [newComment, setNewComment] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const disputeId = params.id as string;
+
+  useEffect(() => {
+    setMode("freelancer");
+    const foundDispute = getFreelancerDisputeById(disputeId);
+    if (foundDispute) {
+      setDispute(foundDispute);
+    }
+  }, [setMode, disputeId]);
+
+  async function handleSubmitComment(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!newComment.trim() || !dispute) return;
+
+    setIsSubmitting(true);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const comment: DisputeComment = {
+      id: `comment-${Date.now()}`,
+      content: newComment.trim(),
+      author: "You",
+      authorRole: "freelancer",
+      timestamp: new Date().toISOString(),
+    };
+
+    setDispute((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        comments: [...prev.comments, comment],
+      };
+    });
+
+    setNewComment("");
+    setIsSubmitting(false);
+  }
+
+  if (!dispute) {
+    return (
+      <div className="page-full-height flex items-center justify-center">
+        <div className={cn(NEUMORPHIC_CARD, "text-center max-w-md")}>
+          <div
+            className={cn(
+              "w-20 h-20 mx-auto mb-4 rounded-full flex items-center justify-center",
+              "bg-background",
+              "shadow-[inset_4px_4px_8px_#d1d5db,inset_-4px_-4px_8px_#ffffff]"
+            )}
+          >
+            <Icon path={ICON_PATHS.flag} size="xl" className="text-text-secondary" />
+          </div>
+          <h2 className="text-xl font-bold text-text-primary mb-2">
+            Dispute not found
+          </h2>
+          <p className="text-text-secondary mb-4">
+            The dispute you are looking for does not exist or has been removed.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.push("/app/freelancer/disputes")}
+            className={cn(PRIMARY_BUTTON, "text-sm")}
+          >
+            Back to Disputes
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-full-height flex flex-col">
+      <div className="flex items-center gap-4 mb-4 flex-shrink-0">
+        <Link href="/app/freelancer/disputes" className={ICON_BUTTON}>
+          <Icon path={ICON_PATHS.chevronLeft} size="md" className="text-text-primary" />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h1 className="text-2xl font-bold text-text-primary truncate">
+              {dispute.offerTitle}
+            </h1>
+            <span
+              className={cn(
+                "px-3 py-1 rounded-lg text-sm font-medium flex-shrink-0",
+                STATUS_COLORS[dispute.status]
+              )}
+            >
+              {DISPUTE_STATUS_LABELS[dispute.status]}
+            </span>
+          </div>
+          <p className="text-text-secondary mt-1">
+            Dispute #{dispute.id} • Opened {formatDate(dispute.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+          <div className="xl:col-span-2 space-y-4">
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Dispute Details
+              </h2>
+              <div className="space-y-4">
+                <div className="flex flex-wrap gap-4">
+                  <div className="flex-1 min-w-[200px]">
+                    <p className="text-text-secondary text-sm mb-1">Reason</p>
+                    <p className="text-text-primary font-medium">
+                      {DISPUTE_REASON_LABELS[dispute.reason]}
+                    </p>
+                  </div>
+                  <div className="flex-1 min-w-[200px]">
+                    <p className="text-text-secondary text-sm mb-1">Client</p>
+                    <p className="text-text-primary font-medium">
+                      {dispute.clientName || "Unknown"}
+                    </p>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Description</p>
+                  <p className="text-text-primary">{dispute.description}</p>
+                </div>
+                <div>
+                  <p className="text-text-secondary text-sm mb-1">Related Service</p>
+                  <Link
+                    href={`/app/freelancer/services/${dispute.offerId}`}
+                    className="inline-flex items-center gap-2 text-primary hover:underline"
+                  >
+                    <Icon path={ICON_PATHS.briefcase} size="sm" />
+                    View Service Details
+                  </Link>
+                </div>
+              </div>
+
+              {dispute.resolution && (
+                <div className={cn("mt-4 p-4 rounded-xl", NEUMORPHIC_INSET)}>
+                  <p className="text-sm font-medium text-success mb-2">Resolution</p>
+                  <p className="text-text-primary">{dispute.resolution}</p>
+                </div>
+              )}
+            </div>
+
+            {dispute.evidence.length > 0 && (
+              <div className={NEUMORPHIC_CARD}>
+                <h2 className="text-lg font-semibold text-text-primary mb-4">
+                  Evidence ({dispute.evidence.length})
+                </h2>
+                <div className="space-y-2">
+                  {dispute.evidence.map((file) => (
+                    <div
+                      key={file.id}
+                      className="flex items-center justify-between p-3 rounded-lg bg-background"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        <Icon
+                          path={file.type.startsWith("image/") ? ICON_PATHS.image : ICON_PATHS.file}
+                          size="md"
+                          className="text-text-secondary flex-shrink-0"
+                        />
+                        <div className="min-w-0">
+                          <p className="text-text-primary text-sm font-medium truncate">
+                            {file.name}
+                          </p>
+                          <p className="text-text-secondary text-xs">
+                            Uploaded {formatDate(file.uploadedAt)}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Comments ({dispute.comments.length})
+              </h2>
+              <div className="space-y-4">
+                {dispute.comments.map((comment) => (
+                  <div
+                    key={comment.id}
+                    className={cn(
+                      "p-4 rounded-xl border",
+                      COMMENT_ROLE_COLORS[comment.authorRole]
+                    )}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-text-primary">
+                          {comment.author}
+                        </span>
+                        <span className="text-xs px-2 py-0.5 rounded bg-background text-text-secondary">
+                          {COMMENT_ROLE_LABELS[comment.authorRole]}
+                        </span>
+                      </div>
+                      <span className="text-text-secondary text-sm">
+                        {formatDateTime(comment.timestamp)}
+                      </span>
+                    </div>
+                    <p className="text-text-primary">{comment.content}</p>
+                  </div>
+                ))}
+
+                {(dispute.status === "open" || dispute.status === "under_review") && (
+                  <form onSubmit={handleSubmitComment} className="mt-4">
+                    <div className={cn("rounded-xl", NEUMORPHIC_INSET)}>
+                      <textarea
+                        value={newComment}
+                        onChange={(e) => setNewComment(e.target.value)}
+                        placeholder="Add a comment..."
+                        rows={3}
+                        className={cn(
+                          "w-full p-4 bg-transparent resize-none",
+                          "text-text-primary placeholder:text-text-secondary/60",
+                          "outline-none"
+                        )}
+                      />
+                    </div>
+                    <div className="flex justify-end mt-3">
+                      <button
+                        type="submit"
+                        disabled={isSubmitting || !newComment.trim()}
+                        className={cn(
+                          PRIMARY_BUTTON,
+                          "disabled:opacity-50 disabled:cursor-not-allowed"
+                        )}
+                      >
+                        {isSubmitting ? "Sending..." : "Send Comment"}
+                      </button>
+                    </div>
+                  </form>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Timeline
+              </h2>
+              <div className="relative">
+                <div className="absolute left-3 top-0 bottom-0 w-0.5 bg-border" />
+                <div className="space-y-4">
+                  {dispute.events.map((event, index) => (
+                    <div key={event.id} className="relative flex gap-4">
+                      <div
+                        className={cn(
+                          "w-6 h-6 rounded-full flex items-center justify-center z-10",
+                          "bg-white",
+                          "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+                          index === 0 ? "ring-2 ring-primary" : ""
+                        )}
+                      >
+                        <Icon
+                          path={EVENT_ICONS[event.type] ?? ICON_PATHS.clock}
+                          size="sm"
+                          className={index === 0 ? "text-primary" : "text-text-secondary"}
+                        />
+                      </div>
+                      <div className="flex-1 pb-4">
+                        <p className="text-text-primary text-sm font-medium">
+                          {event.description}
+                        </p>
+                        <p className="text-text-secondary text-xs mt-1">
+                          {formatDateTime(event.timestamp)}
+                        </p>
+                        <p className="text-text-secondary text-xs">
+                          by {event.actor}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className={NEUMORPHIC_CARD}>
+              <h2 className="text-lg font-semibold text-text-primary mb-4">
+                Quick Info
+              </h2>
+              <div className="space-y-3">
+                <InfoRow label="Status">
+                  <span
+                    className={cn(
+                      "px-2 py-0.5 rounded text-xs font-medium",
+                      STATUS_COLORS[dispute.status]
+                    )}
+                  >
+                    {DISPUTE_STATUS_LABELS[dispute.status]}
+                  </span>
+                </InfoRow>
+                <InfoRow label="Created">
+                  <span className="text-text-primary text-sm">
+                    {formatDate(dispute.createdAt)}
+                  </span>
+                </InfoRow>
+                <InfoRow label="Last Updated">
+                  <span className="text-text-primary text-sm">
+                    {formatDate(dispute.updatedAt)}
+                  </span>
+                </InfoRow>
+                <InfoRow label="Evidence Files">
+                  <span className="text-text-primary text-sm">
+                    {dispute.evidence.length}
+                  </span>
+                </InfoRow>
+                <InfoRow label="Comments">
+                  <span className="text-text-primary text-sm">
+                    {dispute.comments.length}
+                  </span>
+                </InfoRow>
+              </div>
+            </div>
+
+            {(dispute.status === "open" || dispute.status === "under_review") && (
+              <div className={NEUMORPHIC_CARD}>
+                <h2 className="text-lg font-semibold text-text-primary mb-4">
+                  Actions
+                </h2>
+                <div className="space-y-3">
+                  <Link
+                    href={`/app/chat?dispute=${dispute.id}`}
+                    className={cn(
+                      "flex items-center gap-3 w-full px-4 py-3 rounded-xl",
+                      "bg-background text-text-primary",
+                      "hover:bg-gray-100 transition-colors cursor-pointer"
+                    )}
+                  >
+                    <Icon path={ICON_PATHS.chat} size="md" />
+                    <span className="font-medium">Contact Support</span>
+                  </Link>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/freelancer/disputes/new/page.tsx
+++ b/src/app/app/freelancer/disputes/new/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { Suspense, useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { useModeStore } from "@/stores/mode-store";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import {
+  NEUMORPHIC_CARD,
+  NEUMORPHIC_INSET,
+  ICON_BUTTON,
+} from "@/lib/styles";
+import { DISPUTE_REASONS, MOCK_FREELANCER_ELIGIBLE_SERVICES } from "@/data/dispute.data";
+import type { DisputeReason } from "@/types/dispute.types";
+
+function NewDisputeForm(): React.JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setMode } = useModeStore();
+
+  const [selectedService, setSelectedService] = useState("");
+  const [selectedReason, setSelectedReason] = useState<DisputeReason | "">("");
+  const [description, setDescription] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setMode("freelancer");
+    const orderParam = searchParams.get("order");
+    const serviceParam = searchParams.get("service");
+    if (serviceParam) {
+      setSelectedService(serviceParam);
+    } else if (orderParam) {
+      // Map order to service for preselection
+      setSelectedService("service-1");
+    }
+  }, [setMode, searchParams]);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    if (e.target.files) {
+      const newFiles = Array.from(e.target.files);
+      setFiles((prev) => [...prev, ...newFiles].slice(0, 5));
+    }
+  }
+
+  function removeFile(index: number): void {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function formatFileSize(bytes: number): string {
+    const KB = 1024;
+    const MB = KB * 1024;
+    if (bytes < KB) return `${bytes} B`;
+    if (bytes < MB) return `${(bytes / KB).toFixed(1)} KB`;
+    return `${(bytes / MB).toFixed(1)} MB`;
+  }
+
+  function validateForm(): boolean {
+    const newErrors: Record<string, string> = {};
+
+    if (!selectedService) {
+      newErrors.service = "Please select a service";
+    }
+    if (!selectedReason) {
+      newErrors.reason = "Please select a reason";
+    }
+    if (!description.trim()) {
+      newErrors.description = "Please provide a description";
+    } else if (description.trim().length < 50) {
+      newErrors.description = "Description must be at least 50 characters";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    setIsSubmitting(true);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    router.push("/app/freelancer/disputes?created=true");
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-4 mb-4 flex-shrink-0">
+        <Link href="/app/freelancer/disputes" className={ICON_BUTTON}>
+          <Icon path={ICON_PATHS.chevronLeft} size="md" className="text-text-primary" />
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">Open a Dispute</h1>
+          <p className="text-text-secondary mt-1">
+            Submit a dispute for a service or payment issue
+          </p>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "flex-1 min-h-0 overflow-y-auto rounded-2xl",
+          "bg-white p-4 sm:p-6",
+          "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+        )}
+      >
+        <form onSubmit={handleSubmit} className="max-w-3xl mx-auto space-y-6">
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Select Service
+            </h2>
+            <div className="space-y-3">
+              {MOCK_FREELANCER_ELIGIBLE_SERVICES.map((service) => (
+                <label
+                  key={service.id}
+                  className={cn(
+                    "flex items-center gap-3 p-4 rounded-xl cursor-pointer",
+                    "transition-all duration-200",
+                    selectedService === service.id
+                      ? "bg-primary/10 shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+                      : "bg-background hover:bg-background/80"
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="service"
+                    value={service.id}
+                    checked={selectedService === service.id}
+                    onChange={(e) => setSelectedService(e.target.value)}
+                    className="w-4 h-4 text-primary accent-primary"
+                  />
+                  <div>
+                    <span className="text-text-primary font-medium">{service.title}</span>
+                    <p className="text-text-secondary text-sm">Client: {service.clientName}</p>
+                  </div>
+                </label>
+              ))}
+            </div>
+            {errors.service && (
+              <p className="text-error text-sm mt-2">{errors.service}</p>
+            )}
+          </div>
+
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Reason for Dispute
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {DISPUTE_REASONS.map((reason) => (
+                <label
+                  key={reason.value}
+                  className={cn(
+                    "flex flex-col p-4 rounded-xl cursor-pointer",
+                    "transition-all duration-200",
+                    selectedReason === reason.value
+                      ? "bg-primary/10 shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+                      : "bg-background hover:bg-background/80"
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="radio"
+                      name="reason"
+                      value={reason.value}
+                      checked={selectedReason === reason.value}
+                      onChange={(e) => setSelectedReason(e.target.value as DisputeReason)}
+                      className="w-4 h-4 text-primary accent-primary"
+                    />
+                    <span className="text-text-primary font-medium">{reason.label}</span>
+                  </div>
+                  <p className="text-text-secondary text-sm mt-2 ml-7">
+                    {reason.description}
+                  </p>
+                </label>
+              ))}
+            </div>
+            {errors.reason && (
+              <p className="text-error text-sm mt-2">{errors.reason}</p>
+            )}
+          </div>
+
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">
+              Describe Your Issue
+            </h2>
+            <div className={cn("rounded-xl", NEUMORPHIC_INSET)}>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Please provide a detailed description of your dispute. Include relevant dates, communications, and any attempts made to resolve the issue directly..."
+                rows={6}
+                className={cn(
+                  "w-full p-4 bg-transparent resize-none",
+                  "text-text-primary placeholder:text-text-secondary/60",
+                  "outline-none"
+                )}
+              />
+            </div>
+            <div className="flex justify-between mt-2">
+              {errors.description ? (
+                <p className="text-error text-sm">{errors.description}</p>
+              ) : (
+                <p className="text-text-secondary text-sm">
+                  Minimum 50 characters required
+                </p>
+              )}
+              <p className="text-text-secondary text-sm">
+                {description.length} characters
+              </p>
+            </div>
+          </div>
+
+          <div className={NEUMORPHIC_CARD}>
+            <h2 className="text-lg font-semibold text-text-primary mb-2">
+              Upload Evidence
+            </h2>
+            <p className="text-text-secondary text-sm mb-4">
+              Upload screenshots, documents, or other files that support your dispute (max 5 files)
+            </p>
+
+            <label
+              className={cn(
+                "flex flex-col items-center justify-center p-8 rounded-xl cursor-pointer",
+                "border-2 border-dashed border-border",
+                "hover:border-primary hover:bg-primary/5",
+                "transition-all duration-200"
+              )}
+            >
+              <Icon path={ICON_PATHS.upload} size="xl" className="text-text-secondary mb-3" />
+              <span className="text-text-primary font-medium">Click to upload files</span>
+              <span className="text-text-secondary text-sm mt-1">
+                PNG, JPG, PDF up to 10MB each
+              </span>
+              <input
+                type="file"
+                multiple
+                accept="image/*,.pdf,.doc,.docx"
+                onChange={handleFileChange}
+                className="hidden"
+                disabled={files.length >= 5}
+              />
+            </label>
+
+            {files.length > 0 && (
+              <div className="mt-4 space-y-2">
+                {files.map((file, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center justify-between p-3 rounded-lg bg-background"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <Icon
+                        path={file.type.startsWith("image/") ? ICON_PATHS.image : ICON_PATHS.file}
+                        size="md"
+                        className="text-text-secondary flex-shrink-0"
+                      />
+                      <div className="min-w-0">
+                        <p className="text-text-primary text-sm font-medium truncate">
+                          {file.name}
+                        </p>
+                        <p className="text-text-secondary text-xs">
+                          {formatFileSize(file.size)}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeFile(index)}
+                      className="p-1.5 text-text-secondary hover:text-error transition-colors cursor-pointer"
+                    >
+                      <Icon path={ICON_PATHS.close} size="sm" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-4">
+            <Link
+              href="/app/freelancer/disputes"
+              className={cn(
+                "px-6 py-3 rounded-xl font-medium",
+                "text-text-secondary hover:text-text-primary",
+                "transition-colors"
+              )}
+            >
+              Cancel
+            </Link>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={cn(
+                "px-8 py-3 rounded-xl font-semibold",
+                "bg-primary text-white",
+                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                "hover:bg-primary-hover hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+                "active:shadow-[inset_4px_4px_8px_rgba(0,0,0,0.1)]",
+                "disabled:opacity-50 disabled:cursor-not-allowed",
+                "transition-all duration-200 cursor-pointer"
+              )}
+            >
+              {isSubmitting ? (
+                <span className="flex items-center gap-2">
+                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  Submitting...
+                </span>
+              ) : (
+                "Submit Dispute"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function LoadingFallback(): React.JSX.Element {
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="flex items-center gap-4">
+        <div className="w-10 h-10 rounded-xl bg-background animate-pulse" />
+        <div className="space-y-2">
+          <div className="h-7 w-48 bg-background rounded animate-pulse" />
+          <div className="h-5 w-64 bg-background rounded animate-pulse" />
+        </div>
+      </div>
+      <div className={cn(NEUMORPHIC_CARD, "h-48 animate-pulse")} />
+      <div className={cn(NEUMORPHIC_CARD, "h-64 animate-pulse")} />
+    </div>
+  );
+}
+
+export default function FreelancerNewDisputePage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <NewDisputeForm />
+    </Suspense>
+  );
+}

--- a/src/app/app/freelancer/disputes/page.tsx
+++ b/src/app/app/freelancer/disputes/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/cn";
+import { useModeStore } from "@/stores/mode-store";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { EmptyState } from "@/components/ui/EmptyState";
+import {
+  NEUMORPHIC_CARD,
+  NEUMORPHIC_INSET,
+} from "@/lib/styles";
+import { getFreelancerDisputes } from "@/data/dispute.data";
+import { DISPUTE_REASON_LABELS, DISPUTE_STATUS_LABELS } from "@/types/dispute.types";
+import type { Dispute, DisputeStatus } from "@/types/dispute.types";
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function getStatusColor(status: DisputeStatus): string {
+  switch (status) {
+    case "open":
+      return "bg-warning/20 text-warning";
+    case "under_review":
+      return "bg-primary/20 text-primary";
+    case "resolved":
+      return "bg-success/20 text-success";
+    case "closed":
+      return "bg-text-secondary/20 text-text-secondary";
+    default:
+      return "bg-background text-text-secondary";
+  }
+}
+
+interface DisputeCardProps {
+  dispute: Dispute;
+}
+
+function DisputeCard({ dispute }: DisputeCardProps): React.JSX.Element {
+  return (
+    <Link
+      href={`/app/freelancer/disputes/${dispute.id}`}
+      className={cn(
+        NEUMORPHIC_CARD,
+        "block hover:shadow-[8px_8px_16px_#d1d5db,-8px_-8px_16px_#ffffff]",
+        "transition-all duration-200"
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-2">
+            <span
+              className={cn(
+                "px-2.5 py-1 rounded-lg text-xs font-medium",
+                getStatusColor(dispute.status)
+              )}
+            >
+              {DISPUTE_STATUS_LABELS[dispute.status]}
+            </span>
+            <span className="text-text-secondary text-sm">
+              {formatDate(dispute.createdAt)}
+            </span>
+          </div>
+          <h3 className="text-lg font-semibold text-text-primary mb-1 truncate">
+            {dispute.offerTitle}
+          </h3>
+          <p className="text-text-secondary text-sm mb-1">
+            Client: {dispute.clientName}
+          </p>
+          <p className="text-text-secondary text-sm mb-2">
+            Reason: {DISPUTE_REASON_LABELS[dispute.reason]}
+          </p>
+          <p className="text-text-secondary text-sm line-clamp-2">
+            {dispute.description}
+          </p>
+        </div>
+        <Icon
+          path={ICON_PATHS.chevronRight}
+          size="md"
+          className="text-text-secondary flex-shrink-0"
+        />
+      </div>
+
+      {dispute.evidence.length > 0 && (
+        <div className="mt-4 pt-4 border-t border-border-light">
+          <div className="flex items-center gap-2 text-text-secondary text-sm">
+            <Icon path={ICON_PATHS.file} size="sm" />
+            <span>{dispute.evidence.length} file(s) attached</span>
+          </div>
+        </div>
+      )}
+
+      {dispute.resolution && (
+        <div className={cn("mt-4 p-3 rounded-lg", NEUMORPHIC_INSET)}>
+          <p className="text-sm text-text-secondary">
+            <span className="font-medium text-success">Resolution:</span>{" "}
+            {dispute.resolution}
+          </p>
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function DisputesContent(): React.JSX.Element {
+  const searchParams = useSearchParams();
+  const { setMode } = useModeStore();
+  const [filter, setFilter] = useState<DisputeStatus | "all">("all");
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+
+  useEffect(() => {
+    setMode("freelancer");
+    if (searchParams.get("created") === "true") {
+      setShowSuccessMessage(true);
+      setTimeout(() => setShowSuccessMessage(false), 5000);
+    }
+  }, [setMode, searchParams]);
+
+  const allDisputes = getFreelancerDisputes();
+  const filteredDisputes =
+    filter === "all"
+      ? allDisputes
+      : allDisputes.filter((dispute) => dispute.status === filter);
+
+  const statusCounts = {
+    all: allDisputes.length,
+    open: allDisputes.filter((d) => d.status === "open").length,
+    under_review: allDisputes.filter((d) => d.status === "under_review").length,
+    resolved: allDisputes.filter((d) => d.status === "resolved").length,
+    closed: allDisputes.filter((d) => d.status === "closed").length,
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {showSuccessMessage && (
+        <div
+          className={cn(
+            "flex items-center gap-3 p-4 rounded-xl mb-4 flex-shrink-0",
+            "bg-success/10 border border-success/20"
+          )}
+        >
+          <Icon path={ICON_PATHS.check} size="md" className="text-success" />
+          <p className="text-success font-medium">
+            Your dispute has been submitted successfully. We will review it shortly.
+          </p>
+          <button
+            onClick={() => setShowSuccessMessage(false)}
+            className="ml-auto text-success hover:text-success/80 cursor-pointer"
+          >
+            <Icon path={ICON_PATHS.close} size="sm" />
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4 flex-shrink-0">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">My Disputes</h1>
+          <p className="text-text-secondary mt-1">
+            View and manage disputes related to your services
+          </p>
+        </div>
+      </div>
+
+      <div className={cn(NEUMORPHIC_CARD, "mb-4 flex-shrink-0")}>
+        <div className="flex flex-wrap gap-2">
+          {(["all", "open", "under_review", "resolved", "closed"] as const).map((status) => (
+            <button
+              key={status}
+              type="button"
+              onClick={() => setFilter(status)}
+              className={cn(
+                "px-4 py-2 rounded-lg text-sm font-medium capitalize",
+                "transition-all duration-200 cursor-pointer",
+                filter === status
+                  ? "bg-primary text-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+                  : "bg-background text-text-secondary hover:text-text-primary shadow-[inset_1px_1px_2px_#d1d5db,inset_-1px_-1px_2px_#ffffff]"
+              )}
+            >
+              {status === "under_review" ? "Under Review" : status} ({statusCounts[status]})
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "flex-1 min-h-0 overflow-y-auto rounded-2xl",
+          "bg-white p-4",
+          "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+        )}
+      >
+        {filteredDisputes.length === 0 ? (
+          <div className="flex items-center justify-center h-full">
+            <EmptyState
+              icon={ICON_PATHS.flag}
+              message={
+                filter === "all"
+                  ? "No disputes found"
+                  : `No ${filter.replace("_", " ")} disputes`
+              }
+            />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {filteredDisputes.map((dispute) => (
+              <DisputeCard key={dispute.id} dispute={dispute} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LoadingFallback(): React.JSX.Element {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div className="space-y-2">
+          <div className="h-8 w-32 bg-background rounded animate-pulse" />
+          <div className="h-5 w-48 bg-background rounded animate-pulse" />
+        </div>
+      </div>
+      <div className={cn(NEUMORPHIC_CARD, "h-14 animate-pulse")} />
+      <div className={cn(NEUMORPHIC_CARD, "h-32 animate-pulse")} />
+      <div className={cn(NEUMORPHIC_CARD, "h-32 animate-pulse")} />
+    </div>
+  );
+}
+
+export default function FreelancerDisputesPage(): React.JSX.Element {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <DisputesContent />
+    </Suspense>
+  );
+}

--- a/src/app/app/freelancer/services/[id]/page.tsx
+++ b/src/app/app/freelancer/services/[id]/page.tsx
@@ -100,7 +100,7 @@ function OrderCard({ order }: OrderCardProps): React.JSX.Element {
 
           {order.hasDispute ? (
             <Link
-              href={`/app/disputes?order=${order.id}`}
+              href={`/app/freelancer/disputes?order=${order.id}`}
               className={cn(
                 "p-2 rounded-lg",
                 "text-error hover:bg-error/10",
@@ -112,7 +112,7 @@ function OrderCard({ order }: OrderCardProps): React.JSX.Element {
             </Link>
           ) : (
             <Link
-              href={`/app/disputes/new?order=${order.id}`}
+              href={`/app/freelancer/disputes/new?order=${order.id}`}
               className={cn(
                 "p-2 rounded-lg",
                 "text-text-secondary hover:text-warning hover:bg-warning/10",

--- a/src/data/dispute.data.ts
+++ b/src/data/dispute.data.ts
@@ -268,3 +268,235 @@ export const MOCK_ELIGIBLE_OFFERS = [
   { id: "offer-4", title: "Logo Design Project" },
   { id: "offer-5", title: "Content Writing Service" },
 ];
+
+// Freelancer-specific mock disputes (disputes where current user is the freelancer)
+export const MOCK_FREELANCER_DISPUTES: Dispute[] = [
+  {
+    id: "f-dispute-1",
+    offerId: "service-1",
+    offerTitle: "Full-Stack Web Development",
+    clientName: "TechCorp Inc.",
+    reason: "payment_dispute",
+    description:
+      "Client has not released payment after I delivered the completed project according to all specifications.",
+    status: "open",
+    evidence: [
+      {
+        id: "f-ev-1",
+        name: "delivery-confirmation.pdf",
+        type: "application/pdf",
+        size: 128000,
+        uploadedAt: "2024-01-18T09:00:00Z",
+      },
+      {
+        id: "f-ev-2",
+        name: "project-screenshots.zip",
+        type: "application/zip",
+        size: 2450000,
+        uploadedAt: "2024-01-18T09:15:00Z",
+      },
+    ],
+    events: [
+      {
+        id: "f-event-1",
+        type: "created",
+        description: "Dispute opened by freelancer",
+        timestamp: "2024-01-18T08:30:00Z",
+        actor: "You",
+        actorRole: "freelancer",
+      },
+      {
+        id: "f-event-2",
+        type: "evidence_added",
+        description: "Evidence files uploaded",
+        timestamp: "2024-01-18T09:15:00Z",
+        actor: "You",
+        actorRole: "freelancer",
+      },
+    ],
+    comments: [
+      {
+        id: "f-comment-1",
+        content:
+          "I completed the project on January 15th and the client confirmed receipt. However, they have not released the payment.",
+        author: "You",
+        authorRole: "freelancer",
+        timestamp: "2024-01-18T08:35:00Z",
+      },
+    ],
+    createdAt: "2024-01-18T08:30:00Z",
+    updatedAt: "2024-01-18T09:15:00Z",
+  },
+  {
+    id: "f-dispute-2",
+    offerId: "service-2",
+    offerTitle: "UI/UX Design Service",
+    clientName: "StartupXYZ",
+    reason: "scope_disagreement",
+    description:
+      "Client is requesting additional features that were not part of the original agreement without additional compensation.",
+    status: "under_review",
+    evidence: [
+      {
+        id: "f-ev-3",
+        name: "original-contract.pdf",
+        type: "application/pdf",
+        size: 95000,
+        uploadedAt: "2024-01-12T14:00:00Z",
+      },
+    ],
+    events: [
+      {
+        id: "f-event-3",
+        type: "created",
+        description: "Dispute opened by freelancer",
+        timestamp: "2024-01-12T13:00:00Z",
+        actor: "You",
+        actorRole: "freelancer",
+      },
+      {
+        id: "f-event-4",
+        type: "status_changed",
+        description: "Dispute status changed to Under Review",
+        timestamp: "2024-01-13T10:00:00Z",
+        actor: "Support Team",
+        actorRole: "admin",
+      },
+      {
+        id: "f-event-5",
+        type: "comment_added",
+        description: "Client responded to the dispute",
+        timestamp: "2024-01-14T11:00:00Z",
+        actor: "StartupXYZ",
+        actorRole: "client",
+      },
+    ],
+    comments: [
+      {
+        id: "f-comment-2",
+        content:
+          "The original scope included 5 screens. The client is now asking for 3 additional screens without offering extra payment.",
+        author: "You",
+        authorRole: "freelancer",
+        timestamp: "2024-01-12T13:05:00Z",
+      },
+      {
+        id: "f-comment-3",
+        content:
+          "We thought these screens were implied in the project description. However, we are willing to negotiate.",
+        author: "StartupXYZ",
+        authorRole: "client",
+        timestamp: "2024-01-14T11:00:00Z",
+      },
+      {
+        id: "f-comment-4",
+        content:
+          "We are reviewing the original contract and will provide a recommendation shortly.",
+        author: "Support Team",
+        authorRole: "admin",
+        timestamp: "2024-01-15T09:00:00Z",
+      },
+    ],
+    createdAt: "2024-01-12T13:00:00Z",
+    updatedAt: "2024-01-15T09:00:00Z",
+  },
+  {
+    id: "f-dispute-3",
+    offerId: "service-3",
+    offerTitle: "Mobile App Development",
+    clientName: "Digital Solutions Ltd",
+    reason: "communication_problems",
+    description:
+      "Client was unresponsive for 3 weeks during the project, causing delays, and now blames me for the timeline.",
+    status: "resolved",
+    evidence: [
+      {
+        id: "f-ev-4",
+        name: "message-history.pdf",
+        type: "application/pdf",
+        size: 156000,
+        uploadedAt: "2024-01-02T10:00:00Z",
+      },
+    ],
+    events: [
+      {
+        id: "f-event-6",
+        type: "created",
+        description: "Dispute opened by freelancer",
+        timestamp: "2024-01-02T09:00:00Z",
+        actor: "You",
+        actorRole: "freelancer",
+      },
+      {
+        id: "f-event-7",
+        type: "status_changed",
+        description: "Dispute status changed to Under Review",
+        timestamp: "2024-01-03T10:00:00Z",
+        actor: "Support Team",
+        actorRole: "admin",
+      },
+      {
+        id: "f-event-8",
+        type: "resolved",
+        description:
+          "Dispute resolved - Deadline extended by 3 weeks due to client delays",
+        timestamp: "2024-01-08T15:00:00Z",
+        actor: "Support Team",
+        actorRole: "admin",
+      },
+    ],
+    comments: [
+      {
+        id: "f-comment-5",
+        content:
+          "I have attached the message history showing my attempts to contact the client from Dec 10-31.",
+        author: "You",
+        authorRole: "freelancer",
+        timestamp: "2024-01-02T09:10:00Z",
+      },
+      {
+        id: "f-comment-6",
+        content:
+          "I apologize for the lack of communication. I had a family emergency but should have notified.",
+        author: "Digital Solutions Ltd",
+        authorRole: "client",
+        timestamp: "2024-01-05T14:00:00Z",
+      },
+      {
+        id: "f-comment-7",
+        content:
+          "Based on the evidence, we are extending the project deadline by 3 weeks to compensate for the communication gap.",
+        author: "Support Team",
+        authorRole: "admin",
+        timestamp: "2024-01-08T15:00:00Z",
+      },
+    ],
+    createdAt: "2024-01-02T09:00:00Z",
+    updatedAt: "2024-01-08T15:00:00Z",
+    resolution:
+      "The project deadline was extended by 3 weeks. Both parties agreed to continue working together with improved communication.",
+  },
+];
+
+// Get all freelancer disputes
+export function getFreelancerDisputes(): Dispute[] {
+  return MOCK_FREELANCER_DISPUTES;
+}
+
+// Get freelancer dispute by ID
+export function getFreelancerDisputeById(disputeId: string): Dispute | undefined {
+  return MOCK_FREELANCER_DISPUTES.find((d) => d.id === disputeId);
+}
+
+// Check if a service/order has an existing dispute (for freelancer)
+export function getFreelancerDisputeByServiceId(serviceId: string): Dispute | undefined {
+  return MOCK_FREELANCER_DISPUTES.find((d) => d.offerId === serviceId);
+}
+
+// Mock eligible services for freelancer dispute form (services with active orders)
+export const MOCK_FREELANCER_ELIGIBLE_SERVICES = [
+  { id: "service-1", title: "Full-Stack Web Development", clientName: "TechCorp Inc." },
+  { id: "service-2", title: "UI/UX Design Service", clientName: "StartupXYZ" },
+  { id: "service-4", title: "React Native App Development", clientName: "Mobile First LLC" },
+  { id: "service-5", title: "API Integration Service", clientName: "DataSync Corp" },
+];

--- a/src/stores/mode-store.ts
+++ b/src/stores/mode-store.ts
@@ -37,6 +37,7 @@ const FREELANCER_NAV_ITEMS: NavigationItem[] = [
   { href: "/app/projects", label: "Find Projects", icon: ICON_PATHS.search },
   { href: "/app/proposals", label: "My Proposals", icon: ICON_PATHS.document },
   { href: "/app/earnings", label: "Earnings", icon: ICON_PATHS.currency },
+  { href: "/app/freelancer/disputes", label: "Disputes", icon: ICON_PATHS.flag },
   { href: "/app/chat", label: "Messages", icon: ICON_PATHS.chat },
   { href: "/app/freelancer/profile", label: "Profile", icon: ICON_PATHS.user },
   { href: "/app/freelancer/portfolio", label: "Portfolio", icon: ICON_PATHS.image },

--- a/src/types/dispute.types.ts
+++ b/src/types/dispute.types.ts
@@ -54,6 +54,7 @@ export interface Dispute {
   updatedAt: string;
   resolution?: string;
   freelancerName?: string;
+  clientName?: string;
 }
 
 export interface DisputeFormData {


### PR DESCRIPTION
## Summary
- Added complete disputes management system for freelancers
- Freelancers can now view, create, and manage disputes related to their services
- Includes dispute list with filtering, detail view with timeline, and new dispute form

## Related Issue
Closes #30
Closes #31

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Verified navigation to `/app/freelancer/disputes` displays list correctly
- Tested filtering by status (All, Open, Under Review, Resolved, Closed)
- Verified dispute detail page shows timeline, comments, and evidence
- Tested new dispute form validation and submission
- Confirmed "Disputes" link appears in freelancer sidebar
- Verified dispute links in service panel work correctly

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
N/A - UI follows existing dispute pages pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)