### PR TITLE
feat: add Rate Client functionality for freelancers (Issue #32)

### DIFF
--- a/src/components/rating/RateClientModal.tsx
+++ b/src/components/rating/RateClientModal.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { StarRating } from "@/components/ui/StarRating";
+import { NEUMORPHIC_CARD, NEUMORPHIC_INSET, PRIMARY_BUTTON } from "@/lib/styles";
+import { addClientRating } from "@/data/rating.data";
+import type { ServiceOrder } from "@/types/service.types";
+
+interface RateClientModalProps {
+  order: ServiceOrder;
+  serviceTitle: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const MIN_COMMENT_LENGTH = 20;
+const MAX_COMMENT_LENGTH = 500;
+
+export function RateClientModal({
+  order,
+  serviceTitle,
+  onClose,
+  onSuccess,
+}: RateClientModalProps): React.JSX.Element {
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{ rating?: string; comment?: string }>({});
+
+  function validate(): boolean {
+    const newErrors: { rating?: string; comment?: string } = {};
+
+    if (rating === 0) {
+      newErrors.rating = "Please select a rating";
+    }
+
+    if (!comment.trim()) {
+      newErrors.comment = "Please add a comment";
+    } else if (comment.trim().length < MIN_COMMENT_LENGTH) {
+      newErrors.comment = `Comment must be at least ${MIN_COMMENT_LENGTH} characters`;
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+
+    // Simulate API call
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Add rating to mock data
+    addClientRating({
+      id: `client-rating-${Date.now()}`,
+      orderId: order.id,
+      clientId: order.clientId,
+      clientName: order.clientName,
+      serviceId: order.serviceId,
+      serviceTitle,
+      rating,
+      comment: comment.trim(),
+      createdAt: new Date().toISOString(),
+    });
+
+    setIsSubmitting(false);
+    onSuccess();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div
+        className={cn(
+          NEUMORPHIC_CARD,
+          "relative w-full max-w-lg animate-scale-in"
+        )}
+      >
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          className={cn(
+            "absolute top-4 right-4 p-2 rounded-lg",
+            "text-text-secondary hover:text-text-primary hover:bg-background",
+            "transition-colors cursor-pointer"
+          )}
+        >
+          <Icon path={ICON_PATHS.close} size="md" />
+        </button>
+
+        {/* Header */}
+        <div className="mb-6">
+          <h2 className="text-xl font-bold text-text-primary">Rate Client</h2>
+          <p className="text-text-secondary mt-1">
+            Share your experience working with {order.clientName}
+          </p>
+        </div>
+
+        {/* Client info */}
+        <div className="flex items-center gap-3 p-4 rounded-xl bg-background mb-6">
+          <div
+            className={cn(
+              "w-12 h-12 rounded-full flex items-center justify-center",
+              "bg-primary text-white font-semibold"
+            )}
+          >
+            {order.clientAvatar}
+          </div>
+          <div>
+            <p className="font-medium text-text-primary">{order.clientName}</p>
+            <p className="text-sm text-text-secondary">{serviceTitle}</p>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          {/* Rating */}
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-text-primary mb-3">
+              How was your experience?
+            </label>
+            <div className="flex justify-center">
+              <StarRating value={rating} onChange={setRating} size="lg" />
+            </div>
+            {rating > 0 && (
+              <p className="text-center text-sm text-text-secondary mt-2">
+                {rating === 1 && "Poor"}
+                {rating === 2 && "Fair"}
+                {rating === 3 && "Good"}
+                {rating === 4 && "Very Good"}
+                {rating === 5 && "Excellent"}
+              </p>
+            )}
+            {errors.rating && (
+              <p className="text-error text-sm text-center mt-2">{errors.rating}</p>
+            )}
+          </div>
+
+          {/* Comment */}
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-text-primary mb-2">
+              Your review
+            </label>
+            <div className={cn("rounded-xl", NEUMORPHIC_INSET)}>
+              <textarea
+                value={comment}
+                onChange={(e) => setComment(e.target.value.slice(0, MAX_COMMENT_LENGTH))}
+                placeholder="Describe your experience working with this client..."
+                rows={4}
+                className={cn(
+                  "w-full p-4 bg-transparent resize-none",
+                  "text-text-primary placeholder:text-text-secondary/60",
+                  "outline-none"
+                )}
+              />
+            </div>
+            <div className="flex justify-between mt-2">
+              {errors.comment ? (
+                <p className="text-error text-sm">{errors.comment}</p>
+              ) : (
+                <p className="text-text-secondary text-sm">
+                  Min {MIN_COMMENT_LENGTH} characters
+                </p>
+              )}
+              <p className="text-text-secondary text-sm">
+                {comment.length}/{MAX_COMMENT_LENGTH}
+              </p>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className={cn(
+                "flex-1 px-4 py-3 rounded-xl font-medium",
+                "text-text-secondary hover:text-text-primary",
+                "bg-background hover:bg-gray-100",
+                "transition-colors cursor-pointer"
+              )}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className={cn(PRIMARY_BUTTON, "flex-1")}
+            >
+              {isSubmitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  Submitting...
+                </span>
+              ) : (
+                "Submit Rating"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/rating/index.ts
+++ b/src/components/rating/index.ts
@@ -1,0 +1,1 @@
+export { RateClientModal } from "./RateClientModal";

--- a/src/data/rating.data.ts
+++ b/src/data/rating.data.ts
@@ -1,4 +1,4 @@
-import type { FreelancerRating } from "@/types/rating.types";
+import type { FreelancerRating, ClientRating } from "@/types/rating.types";
 
 const ratingsById = new Map<string, FreelancerRating>([
   [
@@ -23,4 +23,35 @@ export function getRatingByOfferId(offerId: string): FreelancerRating | undefine
 
 export function addRating(rating: FreelancerRating): void {
   ratingsById.set(rating.offerId, rating);
+}
+
+// Client ratings (freelancers rating their clients)
+const clientRatingsById = new Map<string, ClientRating>([
+  [
+    "ord-3",
+    {
+      id: "client-rating-1",
+      orderId: "ord-3",
+      clientId: "client-emily",
+      clientName: "Emily Rodriguez",
+      serviceId: "1",
+      serviceTitle: "Professional React & Next.js Web Development",
+      rating: 5,
+      comment:
+        "Emily was a fantastic client! Clear requirements, quick responses, and prompt payment. Would love to work with her again.",
+      createdAt: "2024-11-25T10:00:00Z",
+    },
+  ],
+]);
+
+export function getClientRatingByOrderId(orderId: string): ClientRating | undefined {
+  return clientRatingsById.get(orderId);
+}
+
+export function hasClientRating(orderId: string): boolean {
+  return clientRatingsById.has(orderId);
+}
+
+export function addClientRating(rating: ClientRating): void {
+  clientRatingsById.set(rating.orderId, rating);
 }

--- a/src/data/service.data.ts
+++ b/src/data/service.data.ts
@@ -81,6 +81,7 @@ export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
   {
     id: "ord-1",
     serviceId: "1",
+    clientId: "client-sarah",
     clientName: "Sarah Johnson",
     clientAvatar: "SJ",
     status: "in_progress",
@@ -92,6 +93,7 @@ export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
   {
     id: "ord-2",
     serviceId: "1",
+    clientId: "client-michael",
     clientName: "Michael Chen",
     clientAvatar: "MC",
     status: "pending",
@@ -103,6 +105,7 @@ export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
   {
     id: "ord-3",
     serviceId: "1",
+    clientId: "client-emily",
     clientName: "Emily Rodriguez",
     clientAvatar: "ER",
     status: "completed",
@@ -114,6 +117,7 @@ export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
   {
     id: "ord-4",
     serviceId: "1",
+    clientId: "client-david",
     clientName: "David Kim",
     clientAvatar: "DK",
     status: "delivered",
@@ -125,6 +129,7 @@ export const MOCK_SERVICE_ORDERS: ServiceOrder[] = [
   {
     id: "ord-5",
     serviceId: "2",
+    clientId: "client-lisa",
     clientName: "Lisa Thompson",
     clientAvatar: "LT",
     status: "in_progress",

--- a/src/types/rating.types.ts
+++ b/src/types/rating.types.ts
@@ -9,6 +9,18 @@ export interface FreelancerRating {
   createdAt: string;
 }
 
+export interface ClientRating {
+  id: string;
+  orderId: string;
+  clientId: string;
+  clientName: string;
+  serviceId: string;
+  serviceTitle: string;
+  rating: number;
+  comment: string;
+  createdAt: string;
+}
+
 export interface RatingFormData {
   rating: number;
   comment: string;

--- a/src/types/service.types.ts
+++ b/src/types/service.types.ts
@@ -45,6 +45,7 @@ export type OrderStatus = "pending" | "in_progress" | "delivered" | "completed" 
 export interface ServiceOrder {
   id: string;
   serviceId: string;
+  clientId: string;
   clientName: string;
   clientAvatar: string;
   status: OrderStatus;


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Rate Client functionality for freelancers

## 🛠️ Issue

- Closes #32

## 📚 Description

- Added complete rating functionality for freelancers to rate their clients after completed services
- Freelancers can now rate clients with stars (1-5) and leave a comment
- One rating per completed transaction is enforced
- Success confirmation is shown after submission

## ✅ Changes applied

- Added `ClientRating` type to `rating.types.ts`
- Added client rating mock data and helper functions to `rating.data.ts`
- Added `clientId` field to `ServiceOrder` type
- Created `RateClientModal` component with star rating and comment form
- Added Rate Client button to Service Panel for completed/delivered orders
- Show success toast after rating submission
- Display green star icon for already rated orders

## 🔍 Evidence/Media (screenshots/videos)

- N/A (UI follows existing modal patterns with neumorphic design)