### PR TITLE
fix: synchronize auth cookie name and use config constants in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { COOKIE_CONFIG } from "@/lib/cookies";
 
-const PUBLIC_ROUTES = ["/", "/login", "/register", "/marketplace", "/faq", "/help"];
 const AUTH_ROUTES = ["/login", "/register"];
 const PRIVATE_ROUTE_PREFIX = "/app";
 
@@ -9,12 +9,12 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Check if user has auth token in cookies (set by Zustand persist)
-  const authStorage = request.cookies.get("auth-storage");
+  const authState = request.cookies.get(COOKIE_CONFIG.AUTH_STATE);
   let isAuthenticated = false;
 
-  if (authStorage?.value) {
+  if (authState?.value) {
     try {
-      const decoded = decodeURIComponent(authStorage.value);
+      const decoded = decodeURIComponent(authState.value);
       const parsed = JSON.parse(decoded);
       // Zustand persist stores state in "state" property
       isAuthenticated = parsed.state?.isAuthenticated === true;


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Fix Auth Middleware Redirect Loop and Synchronize Cookie Names


## 🛠️ Issue

- Closes #76 

## 📚 Description
This PR addresses a critical issue where the authentication middleware failed to correctly detect the user's session, leading to an infinite redirect loop to the login page even after a successful sign-in.

### Root Cause
The middleware was looking for a cookie named `"auth-storage"`, while the application's auth store (Zustand) and cookie configuration were actually using `"auth-state"`. This mismatch caused the middleware to always treat users as unauthenticated.


## ✅ Changes applied
- **Synchronized Cookie Names**: Updated [src/middleware.ts](cci:7://file:///Users/kicamo/Desktop/Drips/OFFER-HUB-Frontend/src/middleware.ts:0:0-0:0) to use `COOKIE_CONFIG.AUTH_STATE` from our centralized configuration.
- **Improved Maintainability**: Replaced hardcoded strings with constants from `@/lib/cookies` to ensure consistency.
- **Lint Fixes**: Removed the unused `PUBLIC_ROUTES` constant in the middleware to resolve TypeScript/ESLint warnings.

## 🔍 Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/fe1da40f-e5d9-4ae7-a787-1292c51692fb

