### PR TITLE
feat(ui): add ConfirmationModal component and replace window.confirm …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1723,6 +1724,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1762,6 +1764,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2235,6 +2238,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2574,6 +2578,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3148,6 +3153,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3333,6 +3339,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5211,6 +5218,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -5595,6 +5603,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5683,6 +5692,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5692,6 +5702,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6394,6 +6405,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6556,6 +6568,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6830,6 +6843,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/app/client/offers/page.tsx
+++ b/src/app/app/client/offers/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { cn } from "@/lib/cn";
 import { useModeStore } from "@/stores/mode-store";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ConfirmationModal } from "@/components/ui/ConfirmationModal";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { NEUMORPHIC_CARD, NEUMORPHIC_INSET, ICON_BUTTON, PRIMARY_BUTTON } from "@/lib/styles";
@@ -20,7 +21,12 @@ interface OfferRowProps {
 
 function OfferRow({ offer, onDelete }: OfferRowProps): React.JSX.Element {
   return (
-    <div className={cn("flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-xl", NEUMORPHIC_INSET)}>
+    <div
+      className={cn(
+        "flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-xl",
+        NEUMORPHIC_INSET
+      )}
+    >
       <div className="flex-1 min-w-0">
         <Link
           href={`/app/client/offers/${offer.id}`}
@@ -79,10 +85,23 @@ export default function ManageOffersPage(): React.JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+
   function handleDelete(id: string): void {
-    if (confirm("Are you sure you want to delete this offer?")) {
-      setOffers((prev) => prev.filter((o) => o.id !== id));
-    }
+    setDeleteTarget(id);
+    setDeleteModalOpen(true);
+  }
+
+  async function handleConfirmDelete(): Promise<void> {
+    if (!deleteTarget) return;
+    setIsConfirming(true);
+    await new Promise((r) => setTimeout(r, 250));
+    setOffers((prev) => prev.filter((o) => o.id !== deleteTarget));
+    setIsConfirming(false);
+    setDeleteTarget(null);
+    setDeleteModalOpen(false);
   }
 
   const filteredOffers = filter === "all" ? offers : offers.filter((o) => o.status === filter);
@@ -133,6 +152,18 @@ export default function ManageOffersPage(): React.JSX.Element {
           </div>
         )}
       </div>
+      <ConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+        title="Delete Offer?"
+        message="Are you sure you want to delete this offer?"
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="danger"
+        icon={ICON_PATHS.trash}
+        isLoading={isConfirming}
+      />
     </div>
   );
 }

--- a/src/app/app/freelancer/services/[id]/page.tsx
+++ b/src/app/app/freelancer/services/[id]/page.tsx
@@ -17,6 +17,7 @@ import { getChatIdByOrderId } from "@/data/chat.data";
 import { hasClientRating } from "@/data/rating.data";
 import { RateClientModal } from "@/components/rating";
 import { Toast } from "@/components/ui/Toast";
+import { ConfirmationModal } from "@/components/ui/ConfirmationModal";
 import type { Service, ServiceOrder, ServiceStatus } from "@/types/service.types";
 
 interface PageProps {
@@ -69,18 +70,14 @@ function OrderCard({ order, onRateClient }: OrderCardProps): React.JSX.Element {
         </div>
         <div>
           <p className="font-medium text-text-primary">{order.clientName}</p>
-          <p className="text-sm text-text-secondary">
-            Ordered {formatDate(order.orderedAt)}
-          </p>
+          <p className="text-sm text-text-secondary">Ordered {formatDate(order.orderedAt)}</p>
         </div>
       </div>
 
       <div className="flex items-center gap-4">
         <div className="text-right hidden sm:block">
           <p className="font-semibold text-text-primary">${order.price}</p>
-          <p className="text-xs text-text-secondary">
-            Due {formatDate(order.deliveryDate)}
-          </p>
+          <p className="text-xs text-text-secondary">Due {formatDate(order.deliveryDate)}</p>
         </div>
 
         <span
@@ -93,15 +90,9 @@ function OrderCard({ order, onRateClient }: OrderCardProps): React.JSX.Element {
         </span>
 
         <div className="flex items-center gap-1">
-          {isCompleted && (
-            alreadyRated ? (
-              <span
-                className={cn(
-                  "p-2 rounded-lg",
-                  "text-success"
-                )}
-                title="Client rated"
-              >
+          {isCompleted &&
+            (alreadyRated ? (
+              <span className={cn("p-2 rounded-lg", "text-success")} title="Client rated">
                 <Icon path={ICON_PATHS.star} size="sm" />
               </span>
             ) : (
@@ -117,8 +108,7 @@ function OrderCard({ order, onRateClient }: OrderCardProps): React.JSX.Element {
               >
                 <Icon path={ICON_PATHS.star} size="sm" />
               </button>
-            )
-          )}
+            ))}
 
           <Link
             href={`/app/chat/${getChatIdByOrderId(order.id)}`}
@@ -169,7 +159,11 @@ interface ServiceActionsProps {
   onDelete: () => void;
 }
 
-function ServiceActions({ service, onStatusChange, onDelete }: ServiceActionsProps): React.JSX.Element {
+function ServiceActions({
+  service,
+  onStatusChange,
+  onDelete,
+}: ServiceActionsProps): React.JSX.Element {
   return (
     <div className={NEUMORPHIC_CARD}>
       <h2 className="text-lg font-semibold text-text-primary mb-4">Actions</h2>
@@ -240,6 +234,8 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
   const [ratingOrder, setRatingOrder] = useState<ServiceOrder | null>(null);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const [, forceUpdate] = useState(0);
+  const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const orders = getOrdersByServiceId(id);
 
   function handleStatusChange(newStatus: ServiceStatus): void {
@@ -249,9 +245,15 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
   }
 
   function handleDelete(): void {
-    if (confirm("Are you sure you want to delete this service? This action cannot be undone.")) {
-      router.push("/app/freelancer/services");
-    }
+    setDeleteModalOpen(true);
+  }
+
+  async function handleConfirmDelete(): Promise<void> {
+    setIsDeleting(true);
+    await new Promise((r) => setTimeout(r, 250));
+    setIsDeleting(false);
+    setDeleteModalOpen(false);
+    router.push("/app/freelancer/services");
   }
 
   function handleRateClient(order: ServiceOrder): void {
@@ -277,9 +279,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
           >
             <Icon path={ICON_PATHS.briefcase} size="xl" className="text-text-secondary" />
           </div>
-          <h2 className="text-xl font-bold text-text-primary mb-2">
-            Service not found
-          </h2>
+          <h2 className="text-xl font-bold text-text-primary mb-2">Service not found</h2>
           <p className="text-text-secondary mb-4">
             The service you are looking for does not exist or has been removed.
           </p>
@@ -291,12 +291,27 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
             Back to Services
           </button>
         </div>
+
+        <ConfirmationModal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setDeleteModalOpen(false)}
+          onConfirm={handleConfirmDelete}
+          title="Delete Service?"
+          message="Are you sure you want to delete this service? This action cannot be undone."
+          confirmText="Delete"
+          cancelText="Cancel"
+          variant="danger"
+          icon={ICON_PATHS.trash}
+          isLoading={isDeleting}
+        />
       </div>
     );
   }
 
   const activeOrders = orders.filter((o) => o.status === "in_progress" || o.status === "pending");
-  const completedOrders = orders.filter((o) => o.status === "completed" || o.status === "delivered");
+  const completedOrders = orders.filter(
+    (o) => o.status === "completed" || o.status === "delivered"
+  );
 
   return (
     <div className="space-y-4">
@@ -306,9 +321,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
         </Link>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold text-text-primary truncate">
-              {service.title}
-            </h1>
+            <h1 className="text-2xl font-bold text-text-primary truncate">{service.title}</h1>
             <span
               className={cn(
                 "px-3 py-1 rounded-lg text-sm font-medium flex-shrink-0",
@@ -327,9 +340,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
         <div className="xl:col-span-2 space-y-4">
           <div className={NEUMORPHIC_CARD}>
-            <h2 className="text-lg font-semibold text-text-primary mb-4">
-              Service Details
-            </h2>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">Service Details</h2>
             <div className="space-y-4">
               <div>
                 <p className="text-text-secondary text-sm mb-1">Description</p>
@@ -369,11 +380,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
               </h2>
               <div className="space-y-3">
                 {activeOrders.map((order) => (
-                  <OrderCard
-                    key={order.id}
-                    order={order}
-                    onRateClient={handleRateClient}
-                  />
+                  <OrderCard key={order.id} order={order} onRateClient={handleRateClient} />
                 ))}
               </div>
             </div>
@@ -386,11 +393,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
               </h2>
               <div className="space-y-3">
                 {completedOrders.map((order) => (
-                  <OrderCard
-                    key={order.id}
-                    order={order}
-                    onRateClient={handleRateClient}
-                  />
+                  <OrderCard key={order.id} order={order} onRateClient={handleRateClient} />
                 ))}
               </div>
             </div>
@@ -398,14 +401,8 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
 
           {orders.length === 0 && (
             <div className={cn(NEUMORPHIC_CARD, "text-center py-8")}>
-              <Icon
-                path={ICON_PATHS.users}
-                size="xl"
-                className="text-gray-300 mx-auto mb-3"
-              />
-              <h3 className="text-lg font-medium text-text-primary mb-1">
-                No orders yet
-              </h3>
+              <Icon path={ICON_PATHS.users} size="xl" className="text-gray-300 mx-auto mb-3" />
+              <h3 className="text-lg font-medium text-text-primary mb-1">No orders yet</h3>
               <p className="text-text-secondary text-sm">
                 Orders from clients will appear here once they start coming in.
               </p>
@@ -421,9 +418,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
           />
 
           <div className={NEUMORPHIC_CARD}>
-            <h2 className="text-lg font-semibold text-text-primary mb-4">
-              Statistics
-            </h2>
+            <h2 className="text-lg font-semibold text-text-primary mb-4">Statistics</h2>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
                 <span className="text-text-secondary">Total Earnings</span>
@@ -433,9 +428,7 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-text-secondary">Active Orders</span>
-                <span className="font-semibold text-text-primary">
-                  {activeOrders.length}
-                </span>
+                <span className="font-semibold text-text-primary">{activeOrders.length}</span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-text-secondary">Completion Rate</span>
@@ -466,6 +459,18 @@ export default function ServiceDetailsPage({ params }: PageProps): React.JSX.Ele
           onClose={() => setShowSuccessToast(false)}
         />
       )}
+      <ConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+        title="Delete Service?"
+        message="Are you sure you want to delete this service? This action cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="danger"
+        icon={ICON_PATHS.trash}
+        isLoading={isDeleting}
+      />
     </div>
   );
 }

--- a/src/app/app/freelancer/services/page.tsx
+++ b/src/app/app/freelancer/services/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ConfirmationModal } from "@/components/ui/ConfirmationModal";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { NEUMORPHIC_CARD, PRIMARY_BUTTON } from "@/lib/styles";
 import { MOCK_SERVICES, SERVICE_CATEGORIES } from "@/data/service.data";
@@ -113,10 +114,24 @@ function ServiceCard({ service, onDelete }: ServiceCardProps): React.JSX.Element
 export default function ServicesPage(): React.JSX.Element {
   const [services, setServices] = useState<Service[]>(MOCK_SERVICES);
 
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false);
+
   function handleDelete(id: string) {
-    if (confirm("Are you sure you want to delete this service?")) {
-      setServices((prev) => prev.filter((s) => s.id !== id));
-    }
+    setDeleteTarget(id);
+    setDeleteModalOpen(true);
+  }
+
+  async function handleConfirmDelete(): Promise<void> {
+    if (!deleteTarget) return;
+    setIsConfirming(true);
+    // small delay to show spinner in UI and mimic async
+    await new Promise((r) => setTimeout(r, 250));
+    setServices((prev) => prev.filter((s) => s.id !== deleteTarget));
+    setIsConfirming(false);
+    setDeleteTarget(null);
+    setDeleteModalOpen(false);
   }
 
   return (
@@ -124,11 +139,12 @@ export default function ServicesPage(): React.JSX.Element {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-text-primary">My Services</h1>
-          <p className="text-text-secondary text-sm">
-            Manage your service offerings
-          </p>
+          <p className="text-text-secondary text-sm">Manage your service offerings</p>
         </div>
-        <Link href="/app/freelancer/services/new" className={cn(PRIMARY_BUTTON, "flex items-center gap-2")}>
+        <Link
+          href="/app/freelancer/services/new"
+          className={cn(PRIMARY_BUTTON, "flex items-center gap-2")}
+        >
           <Icon path={ICON_PATHS.plus} size="sm" />
           Create Service
         </Link>
@@ -150,6 +166,19 @@ export default function ServicesPage(): React.JSX.Element {
           ))}
         </div>
       )}
+
+      <ConfirmationModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+        title="Delete Service?"
+        message="Are you sure you want to delete this service? This action cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        variant="danger"
+        icon={ICON_PATHS.trash}
+        isLoading={isConfirming}
+      />
     </div>
   );
 }

--- a/src/components/ui/ConfirmationModal.tsx
+++ b/src/components/ui/ConfirmationModal.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useEffect, useId, useState } from "react";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
+import { NEUMORPHIC_CARD } from "@/lib/styles";
+
+export interface ConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: "danger" | "warning" | "info";
+  icon?: string;
+  isLoading?: boolean;
+}
+
+interface VariantConfig {
+  colorClass: string;
+  bgTint: string;
+  buttonBg: string;
+  defaultIcon: string;
+}
+
+const VARIANT_CONFIG: Record<NonNullable<ConfirmationModalProps["variant"]>, VariantConfig> = {
+  danger: {
+    colorClass: "text-error",
+    bgTint: "bg-error/10",
+    buttonBg: "bg-error",
+    defaultIcon: ICON_PATHS.trash,
+  },
+  warning: {
+    colorClass: "text-warning",
+    bgTint: "bg-warning/10",
+    buttonBg: "bg-warning",
+    defaultIcon: ICON_PATHS.alertCircle,
+  },
+  info: {
+    colorClass: "text-primary",
+    bgTint: "bg-primary/10",
+    buttonBg: "bg-primary",
+    defaultIcon: ICON_PATHS.infoCircle,
+  },
+};
+
+export function ConfirmationModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "danger",
+  icon,
+  isLoading,
+}: ConfirmationModalProps): React.JSX.Element | null {
+  const id = useId();
+  const titleId = `confirmation-title-${id}`;
+  const descId = `confirmation-desc-${id}`;
+  const cfg = VARIANT_CONFIG[variant];
+
+  const [internalLoading, setInternalLoading] = useState(false);
+  const effectiveLoading = isLoading ?? internalLoading;
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    if (isOpen) {
+      window.addEventListener("keydown", onKey);
+    }
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  async function handleConfirm() {
+    try {
+      if (isLoading === undefined) setInternalLoading(true);
+      await onConfirm();
+    } finally {
+      if (isLoading === undefined) setInternalLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className={cn(NEUMORPHIC_CARD, "relative w-full max-w-md animate-scale-in p-6")}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-4 right-4 p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-background transition-colors"
+          aria-label="Close"
+        >
+          <Icon path={ICON_PATHS.close} size="md" />
+        </button>
+
+        {/* Icon */}
+        <div className="flex flex-col items-center text-center">
+          <div
+            className={cn(
+              "w-16 h-16 rounded-full flex items-center justify-center mb-4",
+              cfg.bgTint,
+              cfg.colorClass
+            )}
+            aria-hidden
+          >
+            <Icon path={(icon as string) || cfg.defaultIcon} size="xl" />
+          </div>
+
+          <h2 id={titleId} className="text-lg font-bold text-text-primary mb-2">
+            {title}
+          </h2>
+          <p id={descId} className="text-sm text-text-secondary mb-6">
+            {message}
+          </p>
+
+          <div className="w-full flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className={cn(
+                "flex-1 px-4 py-3 rounded-xl font-medium",
+                "text-text-secondary hover:text-text-primary",
+                "bg-background hover:bg-gray-100 transition-colors"
+              )}
+            >
+              {cancelText}
+            </button>
+
+            <button
+              type="button"
+              onClick={handleConfirm}
+              disabled={effectiveLoading}
+              className={cn(
+                "flex-1 px-4 py-3 rounded-xl font-medium text-white",
+                cfg.buttonBg,
+                "disabled:opacity-70 disabled:cursor-not-allowed"
+              )}
+            >
+              {effectiveLoading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <LoadingSpinner size="sm" className="text-white" />
+                  <span>Processing...</span>
+                </span>
+              ) : (
+                confirmText
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# PR: feat(ui): add reusable ConfirmationModal and replace window.confirm usages

Branch: feature/confirmation-modal -> Base: main

## Summary

This PR adds a reusable, accessible, and neumorphic-styled `ConfirmationModal` component and replaces existing usages of the native `window.confirm()` prompt in three places with the new component so confirmations match the project's design language.


Close #83 

## Files added / changed

- Added: `src/components/ui/ConfirmationModal.tsx` — reusable modal component
- Updated: `src/app/app/freelancer/services/page.tsx` — replaced `confirm()` with modal
- Updated: `src/app/app/freelancer/services/[id]/page.tsx` — replaced `confirm()` with modal
- Updated: `src/app/app/client/offers/page.tsx` — replaced `confirm()` with modal

## What this implements

- Named export `ConfirmationModal` at `src/components/ui/ConfirmationModal.tsx`
- Props typed via `ConfirmationModalProps` with no usage of `any`
- Visual variants: `danger`, `warning`, `info`
- Backdrop with blur and click-outside to close
- Scale-in animation using the existing `animate-scale-in` class
- Close button (✕) in top-right
- Optional icon in circular tint background matching the variant
- Loading state with spinner in confirm button (disables buttons while loading)
- Keyboard support: `Escape` closes modal
- Accessibility: `role="alertdialog"`, `aria-labelledby`, and `aria-describedby`
- Uses existing `NEUMORPHIC_CARD` style tokens and Tailwind classes
- Responsive: constrained to `max-w-md`, padding on mobile

## Acceptance criteria mapping

- Component created at `/src/components/ui/ConfirmationModal.tsx` — yes
- Props fully typed (no `any`) — yes
- 3 visual variants (danger, warning, info) — yes
- Backdrop with blur and click-outside to close — yes
- Scale-in animation on open (uses existing CSS) — yes
- Close button (✕) in top-right corner — yes
- Optional icon with circle and tint background — yes
- Loading state with spinner in confirm button — yes
- Keyboard support: ESC closes modal — yes
- Accessibility: `role="alertdialog"`, ARIA labels — yes
- Neumorphic design consistent with project tokens — yes
- Responsive: `max-w-md` with padding on mobile — yes
- Named export (not default) — yes

## How to test locally

1. Install and run dev server:

```bash
npm install
npm run dev
```

2. Test pages in the UI:
- Freelancer services list: `/app/freelancer/services` — click a service Delete button
- Freelancer service details: `/app/freelancer/services/<id>` — use the Delete action
- Client offers list: `/app/client/offers` — click Delete on an offer

Verify:
- Modal appears with neumorphic style and icon tint
- Clicking outside or pressing `Esc` closes the modal
- Confirm button shows a spinner while processing and disables actions
- After confirm completes, the mocked deletion logic runs (list item removed or navigation happens)

.

## Reviewer checklist

- [ ] Confirm the new modal meets accessibility checks (screen reader announcements, focus management as needed)
- [ ] Confirm visual tokens match the style guide
- [ ] Confirm ESC/Click-outside and focus behavior are acceptable
- [ ] Suggest any UX or wording improvements for confirm/cancel text


## Preview
<img width="1433" height="787" alt="Screenshot 2026-02-21 at 22 47 36" src="https://github.com/user-attachments/assets/de4d6908-2711-4af4-95f6-9659c3da16ba" />
<img width="1433" height="787" alt="Screenshot 2026-02-21 at 22 48 01" src="https://github.com/user-attachments/assets/1884df6b-f375-48e3-8c97-4f6d632697d5" />
<img width="1433" height="787" alt="Screenshot 2026-02-21 at 22 49 32" src="https://github.com/user-attachments/assets/29883301-c223-4fb7-a061-5c125f19eda2" />




