### PR TITLE
feat: Implement hire service flow with modal and purchases page

### DIFF
--- a/src/app/app/client/purchases/page.tsx
+++ b/src/app/app/client/purchases/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useModeStore } from "@/stores/mode-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { getMyPurchases } from "@/lib/api/orders";
+import type { Order } from "@/types/order.types";
+import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { cn } from "@/lib/cn";
+
+const STATUS_CONFIG: Record<string, { label: string; color: string; bgColor: string }> = {
+  ORDER_CREATED: { label: "Created", color: "text-blue-600", bgColor: "bg-blue-100" },
+  FUNDS_RESERVED: { label: "Funds Reserved", color: "text-yellow-600", bgColor: "bg-yellow-100" },
+  ESCROW_CREATING: { label: "Creating Escrow", color: "text-orange-600", bgColor: "bg-orange-100" },
+  ESCROW_FUNDING: { label: "Funding Escrow", color: "text-orange-600", bgColor: "bg-orange-100" },
+  IN_PROGRESS: { label: "In Progress", color: "text-primary", bgColor: "bg-primary/10" },
+  COMPLETED: { label: "Completed", color: "text-success", bgColor: "bg-success/10" },
+  RELEASED: { label: "Released", color: "text-success", bgColor: "bg-success/10" },
+  REFUNDED: { label: "Refunded", color: "text-warning", bgColor: "bg-warning/10" },
+  CLOSED: { label: "Closed", color: "text-text-secondary", bgColor: "bg-gray-100" },
+  DISPUTED: { label: "Disputed", color: "text-error", bgColor: "bg-error/10" },
+};
+
+const STATUS_FILTER_OPTIONS = [
+  { value: "", label: "All Status" },
+  { value: "ORDER_CREATED", label: "Created" },
+  { value: "FUNDS_RESERVED", label: "Funds Reserved" },
+  { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "COMPLETED", label: "Completed" },
+  { value: "RELEASED", label: "Released" },
+  { value: "CLOSED", label: "Closed" },
+];
+
+export default function ClientPurchasesPage() {
+  const { setMode } = useModeStore();
+  const { token } = useAuthStore();
+
+  const [purchases, setPurchases] = useState<Order[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState("");
+
+  useEffect(() => {
+    setMode("client");
+  }, [setMode]);
+
+  useEffect(() => {
+    async function fetchPurchases() {
+      if (!token) return;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await getMyPurchases(token, {
+          status: statusFilter || undefined,
+          limit: 50,
+        });
+        setPurchases(response.data);
+      } catch (err) {
+        console.error("Failed to fetch purchases:", err);
+        setError(err instanceof Error ? err.message : "Failed to fetch purchases");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchPurchases();
+  }, [token, statusFilter]);
+
+  function formatDate(dateString: string): string {
+    return new Date(dateString).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  function getStatusConfig(status: string) {
+    return STATUS_CONFIG[status] || { label: status, color: "text-text-secondary", bgColor: "bg-gray-100" };
+  }
+
+  return (
+    <div className="space-y-6 pb-12">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-extrabold text-text-primary tracking-tight">My Purchases</h1>
+          <p className="text-text-secondary mt-1">Services you've hired from freelancers</p>
+        </div>
+
+        {/* Status Filter */}
+        <div className="flex items-center gap-2">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className={cn(
+              "px-4 py-2 rounded-xl bg-background text-text-primary text-sm",
+              "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+              "focus:outline-none"
+            )}
+          >
+            {STATUS_FILTER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <LoadingSpinner className="text-primary" />
+        </div>
+      ) : error ? (
+        <EmptyState
+          icon={ICON_PATHS.alertCircle}
+          message={error}
+        />
+      ) : purchases.length === 0 ? (
+        <EmptyState
+          icon={ICON_PATHS.shoppingCart}
+          message={statusFilter ? "No purchases match this filter" : "You haven't hired any services yet"}
+          action={
+            <Link
+              href="/marketplace/services"
+              className={cn(
+                "inline-flex items-center gap-2 px-6 py-3 rounded-xl",
+                "bg-primary text-white font-medium",
+                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+                "transition-all duration-200"
+              )}
+            >
+              <Icon path={ICON_PATHS.search} size="sm" />
+              <span>Browse Services</span>
+            </Link>
+          }
+        />
+      ) : (
+        <div className="space-y-4">
+          {purchases.map((order) => {
+            const statusConfig = getStatusConfig(order.status);
+            const metadata = order.metadata as Record<string, any> | null;
+            const serviceTitle = metadata?.serviceTitle || order.title || "Service Order";
+            const sellerName = order.seller?.email?.split("@")[0] || "Freelancer";
+
+            return (
+              <Link
+                key={order.id}
+                href={`/app/orders/${order.id}`}
+                className={cn(
+                  "block p-6 rounded-2xl bg-white transition-all duration-200",
+                  "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                  "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+                )}
+              >
+                <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+                  {/* Left: Order Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-2">
+                      <h3 className="font-semibold text-text-primary truncate">
+                        {serviceTitle}
+                      </h3>
+                      <span className={cn(
+                        "px-2.5 py-1 rounded-full text-xs font-medium",
+                        statusConfig.bgColor,
+                        statusConfig.color
+                      )}>
+                        {statusConfig.label}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-4 text-sm text-text-secondary">
+                      <div className="flex items-center gap-1.5">
+                        <Icon path={ICON_PATHS.user} size="sm" />
+                        <span>{sellerName}</span>
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <Icon path={ICON_PATHS.calendar} size="sm" />
+                        <span>{formatDate(order.createdAt)}</span>
+                      </div>
+                      {metadata?.deliveryDays && (
+                        <div className="flex items-center gap-1.5">
+                          <Icon path={ICON_PATHS.clock} size="sm" />
+                          <span>{metadata.deliveryDays} days delivery</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Right: Price */}
+                  <div className="flex items-center gap-4">
+                    <div className="text-right">
+                      <p className="text-xs text-text-secondary">Amount</p>
+                      <p className="text-xl font-bold text-primary">
+                        ${parseFloat(order.amount).toLocaleString()}
+                      </p>
+                    </div>
+                    <Icon path={ICON_PATHS.chevronRight} size="md" className="text-text-secondary" />
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/marketplace/services/[id]/page.tsx
+++ b/src/app/marketplace/services/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Toast } from "@/components/ui/Toast";
 import { Navbar } from "@/components/landing/Navbar";
+import { HireServiceModal } from "@/components/marketplace/HireServiceModal";
 import { useAuthStore } from "@/stores/auth-store";
 import { cn } from "@/lib/cn";
 
@@ -33,7 +34,7 @@ export default function ServiceDetailPage(): React.JSX.Element {
   const [service, setService] = useState<MarketplaceService | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [isHiring, setIsHiring] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
   useEffect(() => {
@@ -214,53 +215,20 @@ export default function ServiceDetailPage(): React.JSX.Element {
 
               {/* Hire Button */}
               {isAuthenticated ? (
-                <>
-                  <button
-                    onClick={async () => {
-                      if (!token) {
-                        router.push(`/login?redirect=/marketplace/services/${serviceId}`);
-                        return;
-                      }
-
-                      setIsHiring(true);
-                      try {
-                        const order = await hireService(token, serviceId);
-                        // Success - redirect to order page
-                        router.push(`/app/orders/${order.id}`);
-                      } catch (error) {
-                        console.error('Failed to hire service:', error);
-                        setToast({
-                          message: error instanceof Error ? error.message : 'Failed to hire service',
-                          type: 'error',
-                        });
-                      } finally {
-                        setIsHiring(false);
-                      }
-                    }}
-                    disabled={isHiring}
-                    className={cn(
-                      "w-full py-3 px-6 rounded-xl flex items-center justify-center gap-2",
-                      "bg-primary text-white font-medium",
-                      "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-                      "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
-                      "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.2)]",
-                      "disabled:opacity-50 disabled:cursor-not-allowed",
-                      "transition-all duration-200"
-                    )}
-                  >
-                    {isHiring ? (
-                      <>
-                        <LoadingSpinner size="sm" />
-                        <span>Hiring...</span>
-                      </>
-                    ) : (
-                      <>
-                        <span>Hire This Service</span>
-                        <Icon path={ICON_PATHS.chevronRight} size="sm" />
-                      </>
-                    )}
-                  </button>
-                </>
+                <button
+                  onClick={() => setIsModalOpen(true)}
+                  className={cn(
+                    "w-full py-3 px-6 rounded-xl flex items-center justify-center gap-2",
+                    "bg-primary text-white font-medium",
+                    "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                    "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+                    "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.2)]",
+                    "transition-all duration-200"
+                  )}
+                >
+                  <span>Hire This Service</span>
+                  <Icon path={ICON_PATHS.chevronRight} size="sm" />
+                </button>
               ) : (
                 <>
                   <Link
@@ -356,6 +324,41 @@ export default function ServiceDetailPage(): React.JSX.Element {
           message={toast.message}
           type={toast.type}
           onClose={() => setToast(null)}
+        />
+      )}
+
+      {/* Hire Service Modal */}
+      {service && (
+        <HireServiceModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          service={service}
+          onSubmit={async (requirements) => {
+            if (!token) {
+              router.push(`/login?redirect=/marketplace/services/${serviceId}`);
+              return;
+            }
+
+            try {
+              const order = await hireService(token, serviceId, requirements);
+              setIsModalOpen(false);
+              setToast({
+                message: 'Order created successfully! Redirecting...',
+                type: 'success',
+              });
+              // Redirect to order page after a brief delay
+              setTimeout(() => {
+                router.push(`/app/orders/${order.id}`);
+              }, 1000);
+            } catch (error) {
+              console.error('Failed to hire service:', error);
+              setToast({
+                message: error instanceof Error ? error.message : 'Failed to hire service',
+                type: 'error',
+              });
+              throw error; // Re-throw to keep modal open
+            }
+          }}
         />
       )}
     </>

--- a/src/app/marketplace/services/page.tsx
+++ b/src/app/marketplace/services/page.tsx
@@ -80,133 +80,133 @@ export default function BrowseServicesPage(): React.JSX.Element {
       <Navbar />
       <div className="min-h-screen bg-background">
         <div className="container mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-text-primary mb-2">Browse Services</h1>
-          <p className="text-text-secondary">
-            Discover professional services from talented freelancers
-          </p>
-        </div>
+          {/* Header */}
+          <div className="mb-8">
+            <h1 className="text-3xl font-bold text-text-primary mb-2">Browse Services</h1>
+            <p className="text-text-secondary">
+              Discover professional services from talented freelancers
+            </p>
+          </div>
 
-        {/* Search Bar */}
-        <form onSubmit={handleSearch} className="mb-8">
-          <div
-            className={cn(
-              "flex items-center gap-4 p-3 rounded-3xl bg-white",
-              "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
-            )}
-          >
+          {/* Search Bar */}
+          <form onSubmit={handleSearch} className="mb-8">
             <div
               className={cn(
-                "flex-1 flex items-center gap-2 px-4 py-2 rounded-xl",
-                "bg-background",
-                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+                "flex items-center gap-4 p-3 rounded-3xl bg-white",
+                "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
               )}
             >
-              <svg
-                className="h-5 w-5 text-text-secondary/50 flex-shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-              <input
-                type="text"
-                placeholder="Search services by title or description..."
-                value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value)}
+              <div
                 className={cn(
-                  "flex-1 py-0.5 text-sm text-text-primary placeholder-text-secondary/50",
-                  "bg-transparent focus:outline-none"
+                  "flex-1 flex items-center gap-2 px-4 py-2 rounded-xl",
+                  "bg-background",
+                  "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
                 )}
-              />
-            </div>
-            <button
-              type="submit"
-              className={cn(
-                "p-2.5 rounded-xl flex-shrink-0",
-                "bg-primary text-white",
-                "hover:bg-primary-hover transition-all duration-200",
-                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-                "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
-                "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.2)]"
-              )}
-              aria-label="Search"
-            >
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              >
+                <svg
+                  className="h-5 w-5 text-text-secondary/50 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+                <input
+                  type="text"
+                  placeholder="Search services by title or description..."
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  className={cn(
+                    "flex-1 py-0.5 text-sm text-text-primary placeholder-text-secondary/50",
+                    "bg-transparent focus:outline-none"
+                  )}
                 />
-              </svg>
-            </button>
-          </div>
-        </form>
-
-        {/* Main Content */}
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Filters Sidebar */}
-          <div className="lg:col-span-1">
-            <MarketplaceFilters filters={filters} onChange={setFilters} priceLabel="Price" />
-          </div>
-
-          {/* Services Grid */}
-          <div className="lg:col-span-3">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-20">
-                <LoadingSpinner className="text-primary" />
               </div>
-            ) : error ? (
-              <EmptyState icon={ICON_PATHS.alertCircle} message={error} />
-            ) : services.length === 0 ? (
-              <EmptyState
-                icon={ICON_PATHS.briefcase}
-                message="No services found. Try adjusting your filters or search terms"
-              />
-            ) : (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                  {services.map((service) => (
-                    <ServiceCard key={service.id} service={service} />
-                  ))}
-                </div>
-
-                {/* Load More Button */}
-                {hasMore && (
-                  <div className="flex justify-center mt-8">
-                    <button
-                      onClick={loadMore}
-                      className={cn(
-                        "px-8 py-3 rounded-xl",
-                        "bg-white text-primary font-medium",
-                        "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-                        "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
-                        "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.1)]",
-                        "transition-all duration-200"
-                      )}
-                    >
-                      Load More
-                    </button>
-                  </div>
+              <button
+                type="submit"
+                className={cn(
+                  "p-2.5 rounded-xl flex-shrink-0",
+                  "bg-primary text-white",
+                  "hover:bg-primary-hover transition-all duration-200",
+                  "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                  "hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+                  "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.2)]"
                 )}
+                aria-label="Search"
+              >
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
 
-                {/* Results Count */}
-                <div className="mt-6 text-center text-sm text-text-secondary">
-                  Showing {services.length} service{services.length !== 1 ? "s" : ""}
-                  {hasMore && " (more available)"}
+          {/* Main Content */}
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+            {/* Filters Sidebar */}
+            <div className="lg:col-span-1">
+              <MarketplaceFilters filters={filters} onChange={setFilters} priceLabel="Price" />
+            </div>
+
+            {/* Services Grid */}
+            <div className="lg:col-span-3">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-20">
+                  <LoadingSpinner className="text-primary" />
                 </div>
-              </>
-            )}
+              ) : error ? (
+                <EmptyState icon={ICON_PATHS.alertCircle} message={error} />
+              ) : services.length === 0 ? (
+                <EmptyState
+                  icon={ICON_PATHS.briefcase}
+                  message="No services found. Try adjusting your filters or search terms"
+                />
+              ) : (
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+                    {services.map((service) => (
+                      <ServiceCard key={service.id} service={service} />
+                    ))}
+                  </div>
+
+                  {/* Load More Button */}
+                  {hasMore && (
+                    <div className="flex justify-center mt-8">
+                      <button
+                        onClick={loadMore}
+                        className={cn(
+                          "px-8 py-3 rounded-xl",
+                          "bg-white text-primary font-medium",
+                          "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                          "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+                          "active:shadow-[inset_3px_3px_6px_rgba(0,0,0,0.1)]",
+                          "transition-all duration-200"
+                        )}
+                      >
+                        Load More
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Results Count */}
+                  <div className="mt-6 text-center text-sm text-text-secondary">
+                    Showing {services.length} service{services.length !== 1 ? "s" : ""}
+                    {hasMore && " (more available)"}
+                  </div>
+                </>
+              )}
+            </div>
           </div>
-        </div>
         </div>
       </div>
     </>

--- a/src/components/marketplace/HireServiceModal.tsx
+++ b/src/components/marketplace/HireServiceModal.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import React, { useState } from "react";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
+import { FormField } from "@/components/ui/FormField";
+import type { MarketplaceService } from "@/lib/api/marketplace";
+
+export interface HireServiceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (requirements: string) => Promise<void>;
+  service: MarketplaceService;
+}
+
+export function HireServiceModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  service,
+}: HireServiceModalProps): React.JSX.Element | null {
+  const [requirements, setRequirements] = useState('');
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [errors, setErrors] = useState<{ requirements?: string; terms?: string }>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const price = parseFloat(service.price);
+  const freelancerName = service.user?.firstName && service.user?.lastName
+    ? `${service.user.firstName} ${service.user.lastName}`
+    : service.user?.username || service.user?.email?.split("@")[0] || "Freelancer";
+
+  function validate(): boolean {
+    const newErrors: typeof errors = {};
+
+    if (!agreedToTerms) {
+      newErrors.terms = 'You must agree to the terms to proceed';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(requirements);
+      setRequirements('');
+      setAgreedToTerms(false);
+      setErrors({});
+    } catch (error) {
+      console.error('Failed to hire service:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleClose() {
+    setRequirements('');
+    setAgreedToTerms(false);
+    setErrors({});
+    onClose();
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={handleClose} />
+
+      <div
+        className={cn(
+          "relative w-full max-w-lg animate-scale-in p-6 max-h-[90vh] overflow-y-auto",
+          "rounded-3xl bg-white",
+          "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h2 className="text-2xl font-bold text-text-primary">Hire Service</h2>
+            <p className="text-sm text-text-secondary mt-1 line-clamp-2">{service.title}</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-background transition-colors"
+            aria-label="Close"
+          >
+            <Icon path={ICON_PATHS.close} size="md" />
+          </button>
+        </div>
+
+        {/* Service Summary */}
+        <div className={cn(
+          "p-4 rounded-xl mb-6",
+          "bg-background",
+          "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+        )}>
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-sm text-text-secondary">Freelancer</span>
+            <span className="text-sm font-medium text-text-primary">{freelancerName}</span>
+          </div>
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-sm text-text-secondary">Price</span>
+            <span className="text-lg font-bold text-primary">${price.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-text-secondary">Delivery Time</span>
+            <span className="text-sm font-medium text-text-primary">
+              {service.deliveryDays} day{service.deliveryDays !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <FormField
+            label="Project Requirements"
+            hint="Describe what you need, any specific details, files, or references (optional)"
+            optional
+          >
+            <textarea
+              value={requirements}
+              onChange={(e) => setRequirements(e.target.value)}
+              rows={4}
+              className={cn(
+                "w-full px-4 py-3 rounded-xl resize-none bg-background",
+                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                "text-text-primary placeholder-text-secondary/50 focus:outline-none"
+              )}
+              placeholder="Please describe your specific requirements, timeline expectations, or any details the freelancer should know..."
+            />
+          </FormField>
+
+          {/* Terms Checkbox */}
+          <div className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              id="terms"
+              checked={agreedToTerms}
+              onChange={(e) => setAgreedToTerms(e.target.checked)}
+              className="mt-1 w-4 h-4 rounded border-gray-300 text-primary focus:ring-primary"
+            />
+            <label htmlFor="terms" className="text-sm text-text-secondary">
+              I understand that by hiring this service, an order will be created and I will need to fund the escrow to start the work.
+            </label>
+          </div>
+          {errors.terms && (
+            <p className="text-xs text-error">{errors.terms}</p>
+          )}
+
+          {/* Info Box */}
+          <div className={cn(
+            "flex items-start gap-3 p-4 rounded-xl",
+            "bg-primary/5 border border-primary/20"
+          )}>
+            <Icon path={ICON_PATHS.infoCircle} size="md" className="text-primary flex-shrink-0 mt-0.5" />
+            <div className="text-xs text-text-secondary">
+              <p className="font-medium text-text-primary mb-1">What happens next?</p>
+              <ol className="list-decimal list-inside space-y-1">
+                <li>An order will be created with status "Order Created"</li>
+                <li>You'll need to reserve funds from your balance</li>
+                <li>Create and fund the escrow to start the work</li>
+                <li>Once completed, release payment to the freelancer</li>
+              </ol>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3 pt-4">
+            <button
+              type="button"
+              onClick={handleClose}
+              className={cn(
+                "flex-1 px-4 py-3 rounded-xl font-medium",
+                "text-text-secondary hover:text-text-primary",
+                "bg-background hover:bg-gray-100 transition-colors"
+              )}
+            >
+              Cancel
+            </button>
+
+            <button
+              type="submit"
+              disabled={isSubmitting || !agreedToTerms}
+              className={cn(
+                "flex-1 px-4 py-3 rounded-xl font-medium text-white",
+                "bg-primary hover:bg-primary-hover transition-colors",
+                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                "disabled:opacity-70 disabled:cursor-not-allowed"
+              )}
+            >
+              {isSubmitting ? (
+                <span className="flex items-center justify-center gap-2">
+                  <LoadingSpinner size="sm" className="text-white" />
+                  <span>Creating Order...</span>
+                </span>
+              ) : (
+                'Confirm & Create Order'
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api/marketplace.ts
+++ b/src/lib/api/marketplace.ts
@@ -44,6 +44,11 @@ export interface MarketplaceService {
   user: {
     id: string;
     email: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+    country: string | null;
   };
 }
 

--- a/src/lib/api/orders.ts
+++ b/src/lib/api/orders.ts
@@ -239,3 +239,38 @@ export async function markOrderCompleted(token: string, orderId: string): Promis
   const data = await response.json();
   return data.data || data;
 }
+
+// =====================
+// My Purchases (Service Orders)
+// =====================
+
+export interface PurchasesResponse {
+  data: Order[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+export async function getMyPurchases(token: string, filters?: {
+  status?: string;
+  limit?: number;
+  cursor?: string;
+}): Promise<PurchasesResponse> {
+  const query = new URLSearchParams();
+
+  if (filters?.status) query.append('status', filters.status);
+  if (filters?.limit) query.append('limit', filters.limit.toString());
+  if (filters?.cursor) query.append('cursor', filters.cursor);
+
+  const response = await fetch(`${API_URL}/orders/my-purchases?${query.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error?.message || 'Failed to fetch purchases');
+  }
+
+  const responseData = await response.json();
+  // Backend wraps response: { data: { data: Order[], hasMore, nextCursor }, meta: {...} }
+  return responseData.data;
+}

--- a/src/stores/mode-store.ts
+++ b/src/stores/mode-store.ts
@@ -46,6 +46,7 @@ const CLIENT_NAV_ITEMS: NavigationItem[] = [
   { href: "/app/orders", label: "Orders", icon: ICON_PATHS.shoppingCart },
   { href: "/app/client/offers", label: "Manage Offers", icon: ICON_PATHS.briefcase },
   { href: "/app/client/offers/new", label: "Create Offer", icon: ICON_PATHS.plus },
+  { href: "/app/client/purchases", label: "My Purchases", icon: ICON_PATHS.currency },
   { href: "/app/disputes", label: "Disputes", icon: ICON_PATHS.flag },
   { href: "/app/chat", label: "Messages", icon: ICON_PATHS.chat },
   { href: "/app/profile", label: "Profile", icon: ICON_PATHS.user },


### PR DESCRIPTION
## Summary
- Add HireServiceModal component for confirming service hire with requirements input
- Integrate modal in service detail page (/marketplace/services/[id])
- Add getMyPurchases API function to fetch service orders
- Create /app/client/purchases page to list hired services with status filter
- Add "My Purchases" link to client navigation sidebar
- Update MarketplaceService type with user profile fields (username, firstName, lastName, avatarUrl, country)

## Test plan
- [ ] Login as client
- [ ] Go to /marketplace/services
- [ ] Click on a service to view details
- [ ] Click "Hire This Service" - modal should open
- [ ] Enter requirements (optional) and check terms
- [ ] Click "Confirm & Create Order" - order should be created
- [ ] Verify redirect to /app/orders/[id]
- [ ] Go to /app/client/purchases - should see the order
- [ ] Test status filter dropdown