### PR TITLE
fix: add GitHub avatars domain and neumorphic fallback

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,11 @@ const nextConfig = {
         hostname: "res.cloudinary.com",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/**",
+      },
     ],
   },
 

--- a/src/components/marketplace/ServiceCard.tsx
+++ b/src/components/marketplace/ServiceCard.tsx
@@ -67,7 +67,7 @@ export function ServiceCard({ service, className }: ServiceCardProps): React.JSX
                 className="w-full h-full object-cover"
               />
             ) : (
-              <div className="w-full h-full bg-gradient-to-br from-primary/20 to-primary/10 text-primary flex items-center justify-center font-bold text-xl">
+              <div className="w-full h-full bg-background shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff] text-primary flex items-center justify-center font-bold text-xl">
                 {initials.toUpperCase()}
               </div>
             )}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

- Fix: Add GitHub avatars domain and neumorphic fallback styling

## 🛠️ Issue

- Fixes 400 image errors for GitHub avatar URLs in production

## 📚 Description

- GitHub avatars were returning 400 errors because the domain wasn't in Next.js image optimization whitelist
- ServiceCard fallback was using gradient instead of neumorphic styling

## ✅ Changes applied

- `next.config.js`: Added `avatars.githubusercontent.com` to `remotePatterns`
- `ServiceCard.tsx`: Changed fallback from gradient to neumorphic inset shadow

## 🔍 Evidence/Media (screenshots/videos)

- Error before: `GET /_next/image?url=https%3A%2F%2Favatars.githubusercontent.com%2F... 400 (Bad Request)`
- After: Images load correctly or show neumorphic styled initials fallback