### PR TITLE
feat: add forgot password link to login page #119

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -153,17 +153,9 @@ function LoginContent() {
         </div>
 
         <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.25s", animationFillMode: "forwards" }}>
-          <div className="flex items-center justify-between mb-2">
-            <label className="text-sm font-medium text-text-primary">
-              Password
-            </label>
-            <Link
-              href="/forgot-password"
-              className="text-xs text-primary hover:text-primary-hover transition-colors"
-            >
-              Forgot?
-            </Link>
-          </div>
+          <label className="block text-sm font-medium text-text-primary mb-2">
+            Password
+          </label>
           <AuthInput
             label=""
             type="password"
@@ -174,6 +166,14 @@ function LoginContent() {
             error={errors.password}
             autoComplete="current-password"
           />
+          <div className="flex justify-end mt-2">
+            <Link
+              href="/forgot-password"
+              className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
+            >
+              Forgot your password?
+            </Link>
+          </div>
         </div>
 
         {/* Submit Button */}


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
feat: add forgot password link to login page

## 🛠️ Issue
- Closes #119

## 📚 Description
Added a "Forgot your password?" link to the login page to allow users to navigate to the password recovery flow. The link is positioned below the password field to follow modern UI patterns and ensure accessibility.

## ✅ Changes applied
- Modified [src/app/login/page.tsx](cci:7://file:///c:/Trabajos%20Progra/DRIPS-WAVE/OFFER-HUB-Frontend/src/app/login/page.tsx:0:0-0:0) to include the forgot password link.
- Replaced the previous "Forgot?" helper text with a dedicated "Forgot your password?" link.
- Styled the link using consistent project tokens (`text-primary`, `hover:text-primary-hover`).
- Aligned the link to the right for better visual hierarchy under the password input.

## 🔍 Evidence/Media (screenshots/videos)
- 
<img width="1885" height="930" alt="image" src="https://github.com/user-attachments/assets/03a83531-db07-4973-9cfe-4e4ee18b097c" />

