### PR TITLE
Feat/chat conversations list UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,14 @@ NEXT_PUBLIC_ERROR_TRACKING_ENABLED=false
 
 # Sentry DSN (if using Sentry)
 # NEXT_PUBLIC_SENTRY_DSN=https://your-sentry-dsn
+
+# ====================================
+# API Configuration
+# ====================================
+
+# Use local backend during development
+NEXT_PUBLIC_USE_LOCAL_API=true
+NEXT_PUBLIC_LOCAL_API_URL=http://localhost:3000/api/v1
+
+# Production backend URL
+NEXT_PUBLIC_PRODUCTION_API_URL=https://offer-hub-api-production.up.railway.app/api/v1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       framer-motion:
         specifier: ^12.34.5
         version: 12.35.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.11.0(react@19.2.4)
       next:
         specifier: ^16.1.1
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1709,6 +1712,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.11.0:
+    resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3950,6 +3958,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.11.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+
 import { API_URL } from "@/config/api";
 
-export async function POST(request: NextRequest) {
+export async function POST (request: NextRequest) {
   try {
     const { email, password } = await request.json();
 

--- a/src/app/app/chat/[id]/page.tsx
+++ b/src/app/app/chat/[id]/page.tsx
@@ -1,23 +1,24 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { ICON_PATHS, Icon } from "@/components/ui/Icon";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { cn } from "@/lib/cn";
-import { Icon, ICON_PATHS } from "@/components/ui/Icon";
-import { ConversationList } from "@/components/chat/ConversationList";
+
 import { ChatHeader } from "@/components/chat/ChatHeader";
+import { ChatInfoPanel } from "@/components/chat/ChatInfoPanel";
+import { ConnectionStatus } from "@/components/chat/ConnectionStatus";
+import { ConversationList } from "@/components/chat/ConversationList";
+import { MOCK_SHARED_FILES } from "@/data/chat.data";
 import { MessageBubble } from "@/components/chat/MessageBubble";
 import { MessageInput } from "@/components/chat/MessageInput";
-import { ChatInfoPanel } from "@/components/chat/ChatInfoPanel";
 import { TypingIndicator } from "@/components/chat/TypingIndicator";
-import { ConnectionStatus } from "@/components/chat/ConnectionStatus";
-import { MOCK_SHARED_FILES } from "@/data/chat.data";
-import { useSidebarStore } from "@/stores/sidebar-store";
-import { useAuthStore } from "@/stores/auth-store";
-import { useChatStore } from "@/stores/chat-store";
-import { useChatSSE } from "@/hooks/use-chat-sse";
-import { useMarkAsRead } from "@/hooks/use-mark-as-read";
+import { cn } from "@/lib/cn";
 import { sendTypingStatus } from "@/lib/api/chat";
+import { useAuthStore } from "@/stores/auth-store";
+import { useChatSSE } from "@/hooks/use-chat-sse";
+import { useChatStore } from "@/stores/chat-store";
+import { useMarkAsRead } from "@/hooks/use-mark-as-read";
+import { useSidebarStore } from "@/stores/sidebar-store";
 
 export default function ChatThreadPage(): React.JSX.Element {
   const params = useParams();
@@ -40,12 +41,7 @@ export default function ChatThreadPage(): React.JSX.Element {
   const typingUsers = useChatStore((s) => s.typingUsers[chatId] ?? new Set<string>());
   const connectionStatus = useChatStore((s) => s.connectionStatus[chatId] ?? "disconnected");
 
-  const {
-    fetchConversations,
-    fetchMessages,
-    fetchMoreMessages,
-    sendMessage,
-  } = useChatStore();
+  const { fetchConversations, fetchMessages, fetchMoreMessages, sendMessage } = useChatStore();
 
   const activeConversation = conversations.find((c) => c.id === chatId);
 
@@ -133,12 +129,10 @@ export default function ChatThreadPage(): React.JSX.Element {
           >
             <Icon path={ICON_PATHS.chat} size="xl" className="text-primary" />
           </div>
-          <h2 className="text-lg font-bold text-text-primary mb-2">
-            Conversation not found
-          </h2>
+          <h2 className="text-lg font-bold text-text-primary mb-2">Conversation not found</h2>
           <button
             type="button"
-            onClick={() => router.push("/app/chat")}
+            onClick={() => router.push("/app/messages")}
             className={cn(
               "px-5 py-2.5 rounded-xl cursor-pointer",
               "bg-primary text-white text-sm font-medium",
@@ -169,13 +163,13 @@ export default function ChatThreadPage(): React.JSX.Element {
       {/* Conversation list sidebar */}
       <div
         className={cn(
-          "flex-shrink-0 bg-white rounded-2xl overflow-hidden",
+          "shrink-0 bg-white rounded-2xl overflow-hidden",
           "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
           "transition-all duration-300 ease-in-out",
           "hidden lg:block",
-          conversationsCollapsed ? "lg:w-[80px]" : "lg:w-[340px]",
+          conversationsCollapsed ? "lg:w-20" : "lg:w-85",
           showConversations &&
-            "fixed inset-y-0 left-0 z-50 w-[340px] m-0 rounded-none block lg:relative lg:rounded-2xl"
+            "fixed inset-y-0 left-0 z-50 w-85 m-0 rounded-none block lg:relative lg:rounded-2xl"
         )}
       >
         <ConversationList
@@ -204,7 +198,7 @@ export default function ChatThreadPage(): React.JSX.Element {
               />
             )}
           </div>
-          <ConnectionStatus status={connectionStatus} className="mr-4 flex-shrink-0" />
+          <ConnectionStatus status={connectionStatus} className="mr-4 shrink-0" />
         </div>
 
         {/* Load older messages */}
@@ -229,12 +223,7 @@ export default function ChatThreadPage(): React.JSX.Element {
         )}
 
         {/* Message list */}
-        <div
-          className={cn(
-            "flex-1 overflow-y-auto p-4 sm:p-6 min-h-0",
-            "bg-background"
-          )}
-        >
+        <div className={cn("flex-1 overflow-y-auto p-4 sm:p-6 min-h-0", "bg-background")}>
           <div className="flex items-center justify-center mb-6">
             <span className="px-3 py-1 text-xs text-text-secondary bg-white rounded-full shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]">
               Today
@@ -253,28 +242,23 @@ export default function ChatThreadPage(): React.JSX.Element {
               </div>
             ))}
 
-            {isParticipantTyping && participant && (
-              <TypingIndicator name={participant.name} />
-            )}
+            {isParticipantTyping && participant && <TypingIndicator name={participant.name} />}
 
             <div ref={messagesEndRef} />
           </div>
         </div>
 
-        <MessageInput
-          onSendMessage={handleSendMessage}
-          onTypingChange={handleTypingChange}
-        />
+        <MessageInput onSendMessage={handleSendMessage} onTypingChange={handleTypingChange} />
       </div>
 
       {/* Info panel */}
       <div
         className={cn(
-          "flex-shrink-0 bg-white rounded-2xl overflow-hidden",
+          "shrink-0 bg-white rounded-2xl overflow-hidden",
           "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
           "transition-all duration-300 ease-in-out",
           "hidden xl:block",
-          showInfo ? "xl:w-[280px]" : "xl:w-0 xl:opacity-0"
+          showInfo ? "xl:w-70" : "xl:w-0 xl:opacity-0"
         )}
       >
         {participant && (

--- a/src/app/app/messages/[id]/page.tsx
+++ b/src/app/app/messages/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../chat/[id]/page";

--- a/src/app/app/messages/page.tsx
+++ b/src/app/app/messages/page.tsx
@@ -1,209 +1,60 @@
 "use client";
 
-import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import { ICON_PATHS, Icon } from "@/components/ui/Icon";
+
+import { ConversationList } from "@/components/chat/ConversationList";
 import { cn } from "@/lib/cn";
-import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
-import { NEUMORPHIC_CARD, NEUMORPHIC_INSET } from "@/lib/styles";
-
-interface Conversation {
-  id: string;
-  name: string;
-  avatar: string;
-  lastMessage: string;
-  time: string;
-  unread: number;
-}
-
-const MOCK_CONVERSATIONS: Conversation[] = [
-  {
-    id: "1",
-    name: "Sarah Chen",
-    avatar: "SC",
-    lastMessage: "Thanks for reaching out! I'd love to discuss your project.",
-    time: "2m ago",
-    unread: 2,
-  },
-  {
-    id: "2",
-    name: "Marcus Johnson",
-    avatar: "MJ",
-    lastMessage: "The designs are ready for review.",
-    time: "1h ago",
-    unread: 0,
-  },
-  {
-    id: "3",
-    name: "Elena Rodriguez",
-    avatar: "ER",
-    lastMessage: "Let me know if you need any revisions.",
-    time: "3h ago",
-    unread: 0,
-  },
-];
-
-function ConversationItem({ conversation, isActive }: { conversation: Conversation; isActive: boolean }) {
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-all",
-        isActive ? NEUMORPHIC_INSET : "hover:bg-background"
-      )}
-    >
-      <div
-        className={cn(
-          "w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0",
-          "bg-primary text-white font-semibold text-sm"
-        )}
-      >
-        {conversation.avatar}
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between">
-          <h3 className="font-medium text-text-primary text-sm">{conversation.name}</h3>
-          <span className="text-xs text-text-secondary">{conversation.time}</span>
-        </div>
-        <p className="text-sm text-text-secondary truncate">{conversation.lastMessage}</p>
-      </div>
-      {conversation.unread > 0 && (
-        <div className="w-5 h-5 rounded-full bg-primary text-white text-xs flex items-center justify-center">
-          {conversation.unread}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function MessagesContent(): React.JSX.Element {
-  const searchParams = useSearchParams();
-  const userId = searchParams.get("user");
-
-  return (
-    <div className="h-[calc(100vh-theme(spacing.32))]">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-text-primary">Messages</h1>
-        <p className="text-text-secondary mt-1">Chat with freelancers and clients</p>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[calc(100%-5rem)]">
-        {/* Conversations List */}
-        <div className={cn(NEUMORPHIC_CARD, "lg:col-span-1 overflow-hidden flex flex-col")}>
-          <div className="mb-4">
-            <div
-              className={cn(
-                "flex items-center gap-2 px-3 py-2 rounded-xl",
-                "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
-              )}
-            >
-              <Icon path={ICON_PATHS.search} size="sm" className="text-text-secondary" />
-              <input
-                type="text"
-                placeholder="Search conversations..."
-                className="flex-1 bg-transparent text-sm outline-none text-text-primary placeholder:text-text-secondary"
-              />
-            </div>
-          </div>
-          <div className="flex-1 overflow-y-auto space-y-2">
-            {MOCK_CONVERSATIONS.map((conversation) => (
-              <ConversationItem
-                key={conversation.id}
-                conversation={conversation}
-                isActive={conversation.id === userId}
-              />
-            ))}
-          </div>
-        </div>
-
-        {/* Chat Area */}
-        <div className={cn(NEUMORPHIC_CARD, "lg:col-span-2 flex flex-col overflow-hidden")}>
-          {userId ? (
-            <>
-              {/* Chat Header */}
-              <div className="flex items-center gap-3 pb-4 border-b border-border-light">
-                <div
-                  className={cn(
-                    "w-10 h-10 rounded-full flex items-center justify-center",
-                    "bg-primary text-white font-semibold"
-                  )}
-                >
-                  {MOCK_CONVERSATIONS.find((c) => c.id === userId)?.avatar || "?"}
-                </div>
-                <div>
-                  <h2 className="font-semibold text-text-primary">
-                    {MOCK_CONVERSATIONS.find((c) => c.id === userId)?.name || "New Conversation"}
-                  </h2>
-                  <p className="text-sm text-text-secondary">Online</p>
-                </div>
-              </div>
-
-              {/* Messages Area */}
-              <div className="flex-1 py-4 overflow-y-auto">
-                <div className="flex flex-col items-center justify-center h-full text-center">
-                  <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-                    <Icon path={ICON_PATHS.chat} size="xl" className="text-primary" />
-                  </div>
-                  <p className="text-text-secondary">Start a conversation</p>
-                  <p className="text-sm text-text-secondary mt-1">
-                    Send a message to begin chatting
-                  </p>
-                </div>
-              </div>
-
-              {/* Message Input */}
-              <div className="pt-4 border-t border-border-light">
-                <div
-                  className={cn(
-                    "flex items-center gap-3 px-4 py-3 rounded-xl",
-                    "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
-                  )}
-                >
-                  <input
-                    type="text"
-                    placeholder="Type a message..."
-                    className="flex-1 bg-transparent outline-none text-text-primary placeholder:text-text-secondary"
-                  />
-                  <button
-                    className={cn(
-                      "p-2 rounded-lg bg-primary text-white cursor-pointer",
-                      "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
-                      "hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-                      "transition-all"
-                    )}
-                  >
-                    <Icon path={ICON_PATHS.chat} size="sm" />
-                  </button>
-                </div>
-              </div>
-            </>
-          ) : (
-            <div className="flex-1 flex flex-col items-center justify-center">
-              <div className="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center mb-4">
-                <Icon path={ICON_PATHS.chat} size="xl" className="text-primary" />
-              </div>
-              <h2 className="text-lg font-semibold text-text-primary mb-2">Your Messages</h2>
-              <p className="text-text-secondary text-center max-w-xs">
-                Select a conversation from the list or contact a freelancer to start chatting
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MessagesLoading(): React.JSX.Element {
-  return (
-    <div className="flex items-center justify-center h-[calc(100vh-theme(spacing.32))]">
-      <LoadingSpinner />
-    </div>
-  );
-}
+import { useChatStore } from "@/stores/chat-store";
+import { useEffect } from "react";
+import { useSidebarStore } from "@/stores/sidebar-store";
 
 export default function MessagesPage(): React.JSX.Element {
+  const { setCollapsed } = useSidebarStore();
+  const { fetchConversations, conversations } = useChatStore();
+
+  useEffect(() => {
+    setCollapsed(true);
+  }, [setCollapsed]);
+
+  useEffect(() => {
+    if (conversations.length === 0) {
+      void fetchConversations();
+    }
+  }, [conversations.length, fetchConversations]);
+
   return (
-    <Suspense fallback={<MessagesLoading />}>
-      <MessagesContent />
-    </Suspense>
+    <div className="page-full-height flex gap-4">
+      <div
+        className={cn(
+          "w-full sm:w-80 lg:w-85 shrink-0",
+          "bg-white rounded-2xl overflow-hidden",
+          "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+        )}
+      >
+        <ConversationList />
+      </div>
+
+      <div
+        className={cn(
+          "hidden sm:flex flex-1 flex-col items-center justify-center",
+          "bg-white rounded-2xl",
+          "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+        )}
+      >
+        <div
+          className={cn(
+            "w-24 h-24 mb-6 rounded-full flex items-center justify-center",
+            "bg-background",
+            "shadow-[inset_4px_4px_8px_#d1d5db,inset_-4px_-4px_8px_#ffffff]"
+          )}
+        >
+          <Icon path={ICON_PATHS.chat} size="xl" className="text-primary" />
+        </div>
+        <h2 className="text-xl font-bold text-text-primary mb-2">Your Messages</h2>
+        <p className="text-text-secondary text-center max-w-xs text-sm">
+          Select a conversation from the list to start messaging
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/components/app-shell/AppSidebar.tsx
+++ b/src/components/app-shell/AppSidebar.tsx
@@ -8,6 +8,7 @@ import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 import { useModeStore, getNavigationItems, type UserMode } from "@/stores/mode-store";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { useChatStore } from "@/stores/chat-store";
 
 const ADMIN_NAV_ITEMS = [
   { href: "/admin/users", label: "Users", icon: ICON_PATHS.users },
@@ -24,7 +25,8 @@ const MODE_TOGGLE_BASE = cn(
   "transition-all duration-200 cursor-pointer"
 );
 
-const MODE_TOGGLE_ACTIVE = "bg-primary text-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]";
+const MODE_TOGGLE_ACTIVE =
+  "bg-primary text-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]";
 const MODE_TOGGLE_INACTIVE = "text-text-secondary hover:text-text-primary";
 
 const NAV_LINK_BASE = cn(
@@ -37,8 +39,7 @@ const NAV_LINK_COLLAPSED = cn(
   "transition-all duration-200"
 );
 
-const NAV_LINK_ACTIVE =
-  "bg-primary text-white shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]";
+const NAV_LINK_ACTIVE = "bg-primary text-white shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]";
 const NAV_LINK_INACTIVE =
   "text-text-secondary hover:bg-background hover:text-text-primary hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]";
 
@@ -62,6 +63,8 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
   const { mode, setMode } = useModeStore();
   const { isCollapsed, toggleCollapsed } = useSidebarStore();
   const { user } = useAuthStore();
+  const conversations = useChatStore((s) => s.conversations);
+  const fetchConversations = useChatStore((s) => s.fetchConversations);
   const [hydrated, setHydrated] = useState(false);
   const isAdmin = user?.type === "ADMIN";
 
@@ -69,7 +72,17 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
     setHydrated(true);
   }, []);
 
+  useEffect(() => {
+    if (conversations.length === 0) {
+      void fetchConversations();
+    }
+  }, [conversations.length, fetchConversations]);
+
   const navItems = getNavigationItems(mode);
+  const totalUnreadMessages = conversations.reduce(
+    (total, conversation) => total + conversation.unreadCount,
+    0
+  );
 
   function isActiveLink(href: string): boolean {
     if (pathname === href) return true;
@@ -101,7 +114,7 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
         "m-6 mr-0",
         "bg-white rounded-2xl",
         "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
-        "flex-shrink-0",
+        "shrink-0",
         "flex flex-col",
         "transition-all duration-300 ease-in-out",
         "hidden lg:flex",
@@ -121,10 +134,7 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
           )}
           title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
         >
-          <Icon
-            path={isCollapsed ? ICON_PATHS.chevronRight : ICON_PATHS.chevronLeft}
-            size="sm"
-          />
+          <Icon path={isCollapsed ? ICON_PATHS.chevronRight : ICON_PATHS.chevronLeft} size="sm" />
         </button>
       </div>
 
@@ -188,25 +198,22 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
       )}
 
       {/* Navigation */}
-      <nav className={cn(
-        "flex-1 space-y-2 overflow-y-auto",
-        isCollapsed ? "p-2" : "p-4 pt-2"
-      )}>
+      <nav className={cn("flex-1 space-y-2 overflow-y-auto", isCollapsed ? "p-2" : "p-4 pt-2")}>
         {navItems.map((item) => {
           // Generate data-tour attribute based on route
           const tourId = item.href.includes("services")
             ? "nav-services"
             : item.href.includes("orders")
-            ? "nav-orders"
-            : item.href.includes("profile")
-            ? "nav-profile"
-            : item.href.includes("marketplace")
-            ? "nav-marketplace"
-            : item.href.includes("dashboard")
-            ? "nav-dashboard"
-            : item.href.includes("analytics")
-            ? "nav-analytics"
-            : undefined;
+              ? "nav-orders"
+              : item.href.includes("profile")
+                ? "nav-profile"
+                : item.href.includes("marketplace")
+                  ? "nav-marketplace"
+                  : item.href.includes("dashboard")
+                    ? "nav-dashboard"
+                    : item.href.includes("analytics")
+                      ? "nav-analytics"
+                      : undefined;
 
           return (
             <Link
@@ -218,6 +225,17 @@ export function AppSidebar(_props: AppSidebarProps): React.JSX.Element {
             >
               <Icon path={item.icon} size="md" />
               {!isCollapsed && <span className="font-medium">{item.label}</span>}
+              {!isCollapsed && item.href === "/app/messages" && totalUnreadMessages > 0 && (
+                <span
+                  className={cn(
+                    "ml-auto min-w-5 h-5 px-1.5",
+                    "rounded-full bg-primary text-white",
+                    "text-[10px] font-bold flex items-center justify-center"
+                  )}
+                >
+                  {totalUnreadMessages > 99 ? "99+" : totalUnreadMessages}
+                </span>
+              )}
             </Link>
           );
         })}

--- a/src/components/chat/ConversationItem.tsx
+++ b/src/components/chat/ConversationItem.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { Conversation } from "@/types/chat.types";
+import { cn } from "@/lib/cn";
+
+interface ConversationItemProps {
+  conversation: Conversation;
+  isActive: boolean;
+  onSelect?: (conversationId: string) => void;
+}
+
+export function ConversationItem({
+  conversation,
+  isActive,
+  onSelect,
+}: ConversationItemProps): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(conversation.id)}
+      className={cn(
+        "w-full text-left flex items-center gap-3 p-3 rounded-xl",
+        "transition-all duration-200 cursor-pointer",
+        isActive
+          ? "bg-primary/10 shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+          : "hover:bg-background hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+      )}
+      aria-current={isActive ? "page" : undefined}
+    >
+      <div className="relative shrink-0">
+        <div
+          className={cn(
+            "w-12 h-12 rounded-full flex items-center justify-center",
+            "bg-linear-to-br from-primary/20 to-accent/20",
+            "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+          )}
+        >
+          <span className="text-sm font-semibold text-text-primary">
+            {conversation.participant.avatar}
+          </span>
+        </div>
+        {conversation.participant.isOnline && (
+          <span className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-white rounded-full" />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-0.5">
+          <h3
+            className={cn(
+              "font-medium text-sm truncate",
+              conversation.unreadCount > 0 && "font-semibold"
+            )}
+          >
+            {conversation.participant.name}
+          </h3>
+          <span className="text-[11px] text-text-secondary shrink-0 ml-2">
+            {conversation.lastMessageTime}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-text-secondary truncate pr-2">
+            {conversation.isTyping ? "typing..." : conversation.lastMessage}
+          </p>
+
+          {conversation.unreadCount > 0 && (
+            <span
+              className={cn(
+                "shrink-0 min-w-5 h-5 px-1.5",
+                "bg-primary text-white text-[10px] font-bold",
+                "rounded-full flex items-center justify-center"
+              )}
+            >
+              {conversation.unreadCount > 99 ? "99+" : conversation.unreadCount}
+            </span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/chat/ConversationList.tsx
+++ b/src/components/chat/ConversationList.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { ICON_PATHS, Icon } from "@/components/ui/Icon";
+import { usePathname, useRouter } from "next/navigation";
+
+import { ConversationItem } from "@/components/chat/ConversationItem";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { cn } from "@/lib/cn";
-import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 import { useChatStore } from "@/stores/chat-store";
+import { useState } from "react";
 
 interface ConversationListProps {
   isCollapsed?: boolean;
@@ -14,20 +16,28 @@ interface ConversationListProps {
 
 export function ConversationList({ isCollapsed = false, onToggleCollapse }: ConversationListProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilter, setActiveFilter] = useState<"all" | "unread">("all");
 
   const conversations = useChatStore((s) => s.conversations);
+  const conversationsLoading = useChatStore((s) => s.conversationsLoading);
+  const conversationsHasMore = useChatStore((s) => s.conversationsHasMore);
+  const fetchMoreConversations = useChatStore((s) => s.fetchMoreConversations);
 
   const filteredConversations = conversations.filter((conv) => {
     const matchesSearch = conv.participant.name.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesFilter = activeFilter === "all" ||
-      (activeFilter === "unread" && conv.unreadCount > 0);
+    const matchesFilter =
+      activeFilter === "all" || (activeFilter === "unread" && conv.unreadCount > 0);
     return matchesSearch && matchesFilter;
   });
 
+  function goToConversation(id: string): void {
+    router.push(`/app/messages/${id}`);
+  }
+
   function isActiveConversation(id: string): boolean {
-    return pathname === `/app/chat/${id}`;
+    return pathname === `/app/chat/${id}` || pathname === `/app/messages/${id}`;
   }
 
   // Collapsed view - just avatars with expand button
@@ -61,7 +71,7 @@ export function ConversationList({ isCollapsed = false, onToggleCollapse }: Conv
           {conversations.slice(0, 10).map((conv) => (
             <Link
               key={conv.id}
-              href={`/app/chat/${conv.id}`}
+              href={`/app/messages/${conv.id}`}
               className="relative flex justify-center group"
               title={conv.participant.name}
             >
@@ -72,12 +82,10 @@ export function ConversationList({ isCollapsed = false, onToggleCollapse }: Conv
                   "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
                   isActiveConversation(conv.id)
                     ? "bg-primary text-white scale-110"
-                    : "bg-gradient-to-br from-primary/10 to-accent/10 text-text-primary group-hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff] group-hover:scale-105"
+                    : "bg-linear-to-br from-primary/10 to-accent/10 text-text-primary group-hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff] group-hover:scale-105"
                 )}
               >
-                <span className="text-xs font-bold">
-                  {conv.participant.avatar}
-                </span>
+                <span className="text-xs font-bold">{conv.participant.avatar}</span>
               </div>
               {conv.unreadCount > 0 && (
                 <span className="absolute -top-1 -right-1 w-5 h-5 bg-primary text-white text-[10px] font-bold rounded-full flex items-center justify-center shadow-sm">
@@ -163,7 +171,11 @@ export function ConversationList({ isCollapsed = false, onToggleCollapse }: Conv
 
       {/* Conversations List */}
       <div className="flex-1 overflow-y-auto p-2">
-        {filteredConversations.length === 0 ? (
+        {conversationsLoading ? (
+          <div className="flex items-center justify-center h-32 text-text-secondary text-sm">
+            Loading conversations...
+          </div>
+        ) : filteredConversations.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-text-secondary">
             <Icon path={ICON_PATHS.chat} size="lg" className="mb-2 opacity-50" />
             <p className="text-sm">No conversations found</p>
@@ -171,81 +183,28 @@ export function ConversationList({ isCollapsed = false, onToggleCollapse }: Conv
         ) : (
           <div className="space-y-2">
             {filteredConversations.map((conv) => (
-              <Link
+              <ConversationItem
                 key={conv.id}
-                href={`/app/chat/${conv.id}`}
+                conversation={conv}
+                isActive={isActiveConversation(conv.id)}
+                onSelect={goToConversation}
+              />
+            ))}
+            {conversationsHasMore && (
+              <button
+                type="button"
+                onClick={() => void fetchMoreConversations()}
                 className={cn(
-                  "flex items-center gap-3 p-3 rounded-xl",
-                  "transition-all duration-200",
-                  isActiveConversation(conv.id)
-                    ? "bg-primary/10 shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
-                    : "hover:bg-background hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+                  "w-full mt-2 px-3 py-2 rounded-lg text-xs font-medium",
+                  "text-primary bg-background",
+                  "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+                  "hover:shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+                  "transition-all duration-200 cursor-pointer"
                 )}
               >
-                {/* Avatar */}
-                <div className="relative flex-shrink-0">
-                  <div
-                    className={cn(
-                      "w-12 h-12 rounded-full flex items-center justify-center",
-                      "bg-gradient-to-br from-primary/20 to-accent/20",
-                      "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
-                    )}
-                  >
-                    <span className="text-sm font-semibold text-text-primary">
-                      {conv.participant.avatar}
-                    </span>
-                  </div>
-                  {conv.participant.isOnline && (
-                    <span className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-white rounded-full" />
-                  )}
-                </div>
-
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between mb-0.5">
-                    <h3 className={cn(
-                      "font-medium text-sm truncate",
-                      conv.unreadCount > 0 ? "text-text-primary font-semibold" : "text-text-primary"
-                    )}>
-                      {conv.participant.name}
-                    </h3>
-                    <span className="text-[11px] text-text-secondary flex-shrink-0 ml-2">
-                      {conv.lastMessageTime}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <p className={cn(
-                      "text-xs truncate pr-2",
-                      conv.unreadCount > 0 ? "text-text-secondary" : "text-text-secondary/70"
-                    )}>
-                      {conv.isTyping ? (
-                        <span className="text-primary italic flex items-center gap-1">
-                          <span className="flex gap-0.5">
-                            <span className="w-1 h-1 bg-primary rounded-full animate-bounce" style={{ animationDelay: "0ms" }} />
-                            <span className="w-1 h-1 bg-primary rounded-full animate-bounce" style={{ animationDelay: "150ms" }} />
-                            <span className="w-1 h-1 bg-primary rounded-full animate-bounce" style={{ animationDelay: "300ms" }} />
-                          </span>
-                          typing...
-                        </span>
-                      ) : (
-                        conv.lastMessage
-                      )}
-                    </p>
-                    {conv.unreadCount > 0 && (
-                      <span
-                        className={cn(
-                          "flex-shrink-0 min-w-[20px] h-5 px-1.5",
-                          "bg-primary text-white text-[10px] font-bold",
-                          "rounded-full flex items-center justify-center"
-                        )}
-                      >
-                        {conv.unreadCount}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </Link>
-            ))}
+                Load more
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -1,16 +1,55 @@
-import { create } from "zustand";
-import type { Conversation, ChatMessage, SSEConnectionStatus } from "@/types/chat.types";
+import type { ChatMessage, Conversation, SSEConnectionStatus } from "@/types/chat.types";
 import {
+  sendMessage as apiSendMessage,
   getConversations,
   getMessages,
-  sendMessage as apiSendMessage,
   markMessagesAsRead,
 } from "@/lib/api/chat";
+
+import { create } from "zustand";
 
 const READ_BATCH_DEBOUNCE_MS = 350;
 
 const readBatchTimers: Record<string, ReturnType<typeof setTimeout> | undefined> = {};
 const readBatchLastMessageId: Record<string, string | undefined> = {};
+
+function parseRelativeLastMessageTime (value: string): number {
+  const normalized = value.trim().toLowerCase();
+  const now = Date.now();
+
+  if (normalized === "just now") return now;
+  if (normalized === "yesterday") return now - 24 * 60 * 60 * 1000;
+
+  const relative = normalized.match(/^(\d+)\s*(m|h|d)\s*ago$/);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unit = relative[2];
+    const multiplier = unit === "m"
+      ? 60 * 1000
+      : unit === "h"
+        ? 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
+    return now - amount * multiplier;
+  }
+
+  const absolute = Date.parse(value);
+  return Number.isNaN(absolute) ? 0 : absolute;
+}
+
+function getConversationActivityTimestamp (conversation: Conversation): number {
+  if (conversation.lastMessageAt) {
+    const parsed = Date.parse(conversation.lastMessageAt);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+
+  return parseRelativeLastMessageTime(conversation.lastMessageTime);
+}
+
+function sortConversationsByRecent (conversations: Conversation[]): Conversation[] {
+  return [...conversations].sort(
+    (a, b) => getConversationActivityTimestamp(b) - getConversationActivityTimestamp(a)
+  );
+}
 
 interface ChatState {
   // Conversations
@@ -78,7 +117,7 @@ export const useChatStore = create<ChatState>()((set, get) => ({
     const res = await getConversations();
     if (res.ok && res.data) {
       set({
-        conversations: res.data.conversations,
+        conversations: sortConversationsByRecent(res.data.conversations),
         conversationsHasMore: res.data.hasMore,
         conversationsCursor: res.data.nextCursor,
       });
@@ -94,7 +133,7 @@ export const useChatStore = create<ChatState>()((set, get) => ({
     const res = await getConversations(conversationsCursor);
     if (res.ok && res.data) {
       set({
-        conversations: [...conversations, ...res.data.conversations],
+        conversations: sortConversationsByRecent([...conversations, ...res.data.conversations]),
         conversationsHasMore: res.data.hasMore,
         conversationsCursor: res.data.nextCursor,
       });
@@ -287,17 +326,22 @@ export const useChatStore = create<ChatState>()((set, get) => ({
   },
 
   updateConversationLastMessage: (conversationId, message) => {
-    set((state) => ({
-      conversations: state.conversations.map((c) =>
+    set((state) => {
+      const updated = state.conversations.map((c) =>
         c.id === conversationId
           ? {
-              ...c,
-              lastMessage: message.content,
-              lastMessageTime: message.timestamp,
-            }
+            ...c,
+            lastMessage: message.content,
+            lastMessageTime: message.timestamp,
+            lastMessageAt: new Date().toISOString(),
+          }
           : c
-      ),
-    }));
+      );
+
+      return {
+        conversations: sortConversationsByRecent(updated),
+      };
+    });
   },
 
   incrementUnread: (conversationId) => {

--- a/src/stores/mode-store.ts
+++ b/src/stores/mode-store.ts
@@ -1,6 +1,7 @@
-import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+
 import { ICON_PATHS } from "@/components/ui/Icon";
+import { create } from "zustand";
 
 export type UserMode = "freelancer" | "client";
 
@@ -38,7 +39,7 @@ const FREELANCER_NAV_ITEMS: NavigationItem[] = [
   { href: "/app/orders", label: "Orders", icon: ICON_PATHS.shoppingCart },
   { href: "/app/freelancer/services", label: "My Services", icon: ICON_PATHS.briefcase },
   { href: "/app/freelancer/disputes", label: "Disputes", icon: ICON_PATHS.flag },
-  { href: "/app/chat", label: "Messages", icon: ICON_PATHS.chat },
+  { href: "/app/messages", label: "Messages", icon: ICON_PATHS.chat },
   { href: "/app/profile", label: "Profile", icon: ICON_PATHS.user },
   { href: "/app/freelancer/portfolio", label: "Portfolio", icon: ICON_PATHS.image },
 ];
@@ -51,10 +52,10 @@ const CLIENT_NAV_ITEMS: NavigationItem[] = [
   { href: "/app/client/offers/new", label: "Create Offer", icon: ICON_PATHS.plus },
   { href: "/app/client/purchases", label: "My Purchases", icon: ICON_PATHS.currency },
   { href: "/app/disputes", label: "Disputes", icon: ICON_PATHS.flag },
-  { href: "/app/chat", label: "Messages", icon: ICON_PATHS.chat },
+  { href: "/app/messages", label: "Messages", icon: ICON_PATHS.chat },
   { href: "/app/profile", label: "Profile", icon: ICON_PATHS.user },
 ];
 
-export function getNavigationItems(mode: UserMode): NavigationItem[] {
+export function getNavigationItems (mode: UserMode): NavigationItem[] {
   return mode === "client" ? CLIENT_NAV_ITEMS : FREELANCER_NAV_ITEMS;
 }

--- a/src/types/chat.types.ts
+++ b/src/types/chat.types.ts
@@ -22,6 +22,7 @@ export interface Conversation {
   participant: ChatUser;
   lastMessage: string;
   lastMessageTime: string;
+  lastMessageAt?: string;
   unreadCount: number;
   isTyping?: boolean;
 }


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: feat: implement chat conversations list UI on Messages page with Zustand, search, unread badges, and responsive layout

-

## 🛠️ Issue

- Closes #135

## 📚 Description

This PR implements the main chat conversations list experience for the Messages flow, including a split layout, reusable conversation UI components, state management integration, unread indicators, and responsive behavior for mobile and desktop.
-

## ✅ Changes applied

- Added Messages entry route with split layout for conversation list + thread area
- Added reusable ConversationList sidebar component behavior for:
  - search/filter
  - unread-only filtering
  - selected conversation highlighting
  - empty/loading states
  - lazy load trigger for additional conversations
- Added reusable ConversationItem component showing:
  - participant avatar and name
  - last message preview (truncated)
  - last message timestamp
  - unread badge
- Added dynamic message-thread route under Messages
- Integrated chat state with Zustand store for conversations, unread state, and conversation ordering
- Ordered conversations by most recent activity
- Added total unread messages badge in app navigation
- Updated navigation Messages route to point to the Messages flow
- Preserved and reused existing SSE-based real-time updates through the existing chat store/hook integration
- Matched existing neumorphic styling and interaction patterns
- Ensured responsive behavior:
  - mobile: list-first flow with thread navigation
  - desktop: split layout with persistent sidebar

-

## 🔍 Evidence/Media (screenshots/videos)

-