### PR TITLE
fix: connect freelancer dashboard to real API endpoint

### DIFF
--- a/src/lib/api/freelancer.ts
+++ b/src/lib/api/freelancer.ts
@@ -38,9 +38,9 @@ export async function getFreelancerStats(token: string): Promise<FreelancerStats
 }
 
 export async function getDashboardStats(token: string): Promise<DashboardStats> {
-  const response = await fetch(`${API_BASE_URL}/freelancer/dashboard/stats`, {
+  const response = await fetch(`${API_BASE_URL}/dashboard/freelancer`, {
     headers: {
-      'Authorization': `Bearer ${token}`,
+      Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
   });
@@ -49,8 +49,20 @@ export async function getDashboardStats(token: string): Promise<DashboardStats> 
     throw new Error('Failed to fetch dashboard stats');
   }
 
-  const data = await response.json();
-  return data.data;
+  const body = await response.json();
+  const { stats, comparison } = body.data;
+
+  return {
+    activeApplications: stats.activeApplications,
+    activeOrders: stats.ordersInProgress,
+    totalEarnings: stats.earningsThisMonth,
+    rating: stats.averageRating !== null ? parseFloat(stats.averageRating) : null,
+    ratingCount: 0,
+    activeApplicationsTrend: null,
+    activeOrdersTrend: null,
+    earningsTrend: comparison?.earnings?.changePercent ?? null,
+    ratingTrend: null,
+  };
 }
 
 export async function getFreelancerActivities(token: string): Promise<FreelancerActivity[]> {


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
Fix: Connect freelancer dashboard to real API endpoint

## 🛠️ Issue

- Closes #204

## 📚 Description

The freelancer dashboard was calling a non-existent endpoint (`/freelancer/dashboard/stats`) that no longer exists. The backend now exposes `GET /dashboard/freelancer` (implemented in API issue #41). This fix updates the API client to call the correct endpoint and maps the backend response shape to the frontend `DashboardStats` type.

## ✅ Changes applied

- Updated `getDashboardStats` in `src/lib/api/freelancer.ts` to call `GET /dashboard/freelancer`
- Added response mapping from backend shape (`stats`, `comparison`) to frontend `DashboardStats` type
- Removed stale endpoint reference that was causing silent 404s

## 🔍 Evidence/Media (screenshots/videos)

-