### PR TITLE
feat: real-time notification delivery via SSE

### DIFF
--- a/src/components/app-shell/AppLayoutClient.tsx
+++ b/src/components/app-shell/AppLayoutClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { cn } from "@/lib/cn";
 import { AppHeader, AppSidebar } from "@/components/app-shell";
 import { OnboardingTour } from "@/components/onboarding";
+import { NotificationToastContainer } from "@/components/notifications/NotificationToastContainer";
 
 interface AppLayoutClientProps {
   children: React.ReactNode;
@@ -15,6 +16,7 @@ export function AppLayoutClient({ children }: AppLayoutClientProps): React.JSX.E
   return (
     <div className="app-no-scroll h-screen bg-background flex flex-col overflow-hidden">
       <OnboardingTour />
+      <NotificationToastContainer />
 
       <a href="#main-content" className="skip-link">
         Skip to main content

--- a/src/components/notifications/NotificationToast.tsx
+++ b/src/components/notifications/NotificationToast.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/cn";
+import type { Notification } from "@/types/notification.types";
+
+const DISMISS_DELAY_MS = 4_000;
+
+interface Props {
+  notification: Notification;
+  onDismiss: () => void;
+}
+
+export function NotificationToast({ notification, onDismiss }: Props): React.JSX.Element {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // Trigger enter animation
+    const frame = requestAnimationFrame(() => setVisible(true));
+
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDismiss, 300);
+    }, DISMISS_DELAY_MS);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-3 w-80 p-4 rounded-2xl bg-white",
+        "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]",
+        "transition-all duration-300",
+        visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
+      )}
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-text-primary truncate">
+          {notification.title}
+        </p>
+        <p className="text-xs text-text-secondary mt-0.5 line-clamp-2">
+          {notification.message}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setVisible(false);
+          setTimeout(onDismiss, 300);
+        }}
+        className="flex-shrink-0 text-text-secondary hover:text-text-primary transition-colors"
+        aria-label="Dismiss notification"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
+          <path
+            fillRule="evenodd"
+            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationToastContainer.tsx
+++ b/src/components/notifications/NotificationToastContainer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useNotificationSSE } from "@/hooks/use-notification-sse";
+import { useNotificationStore } from "@/stores/notification-store";
+import { NotificationToast } from "./NotificationToast";
+import type { Notification } from "@/types/notification.types";
+
+interface ToastEntry {
+  id: string;
+  notification: Notification;
+}
+
+export function NotificationToastContainer(): React.JSX.Element {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  // Show a toast whenever a new unread notification arrives at the front
+  useEffect(() => {
+    return useNotificationStore.subscribe((state, prevState) => {
+      const latest = state.notifications[0];
+      const previous = prevState.notifications[0];
+      if (latest && latest !== previous && !latest.isRead) {
+        setToasts((prev) => [
+          { id: latest.id, notification: latest },
+          ...prev.slice(0, 4),
+        ]);
+      }
+    });
+  }, []);
+
+  // Mount the SSE connection
+  useNotificationSSE();
+
+  return (
+    <div
+      className="fixed top-4 right-4 z-[9999] flex flex-col gap-3 pointer-events-none"
+      aria-label="Notifications"
+    >
+      {toasts.map((t) => (
+        <div key={t.id} className="pointer-events-auto">
+          <NotificationToast
+            notification={t.notification}
+            onDismiss={() => dismiss(t.id)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/use-notification-sse.ts
+++ b/src/hooks/use-notification-sse.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useAuthStore } from "@/stores/auth-store";
+import { useNotificationStore } from "@/stores/notification-store";
+import { API_URL } from "@/config/api";
+import type { Notification } from "@/types/notification.types";
+
+const MIN_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const BACKOFF_MULTIPLIER = 2;
+
+function buildSSEUrl(token: string): string {
+  return `${API_URL}/notifications/stream?token=${encodeURIComponent(token)}`;
+}
+
+export function useNotificationSSE(): void {
+  const token = useAuthStore((s) => s.token);
+  const { pushNotification, incrementUnread } = useNotificationStore();
+
+  const esRef = useRef<EventSource | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
+  const tokenRef = useRef(token);
+
+  tokenRef.current = token;
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const closeConnection = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+    clearRetryTimer();
+  }, [clearRetryTimer]);
+
+  const connect = useCallback(() => {
+    if (!isMountedRef.current || !tokenRef.current) return;
+
+    closeConnection();
+
+    const es = new EventSource(buildSSEUrl(tokenRef.current));
+    esRef.current = es;
+
+    es.addEventListener("new_notification", (e: MessageEvent) => {
+      try {
+        const notification: Notification = JSON.parse(e.data);
+        pushNotification(notification);
+        incrementUnread();
+        retryCountRef.current = 0;
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    es.addEventListener("notification_read", (e: MessageEvent) => {
+      try {
+        const { id } = JSON.parse(e.data) as { id: string };
+        useNotificationStore.getState().markAsRead(id);
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    es.onerror = () => {
+      if (!isMountedRef.current) return;
+      closeConnection();
+
+      const backoff = Math.min(
+        MIN_BACKOFF_MS * Math.pow(BACKOFF_MULTIPLIER, retryCountRef.current),
+        MAX_BACKOFF_MS,
+      );
+      retryCountRef.current += 1;
+
+      retryTimerRef.current = setTimeout(() => {
+        if (isMountedRef.current) connect();
+      }, backoff);
+    };
+  }, [closeConnection, pushNotification, incrementUnread]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    if (token) connect();
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && tokenRef.current) connect();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      isMountedRef.current = false;
+      closeConnection();
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [token, connect, closeConnection]);
+}

--- a/src/stores/notification-store.ts
+++ b/src/stores/notification-store.ts
@@ -20,6 +20,8 @@ interface NotificationState {
   fetchMore: () => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
   markAllAsRead: () => Promise<void>;
+  pushNotification: (notification: Notification) => void;
+  incrementUnread: () => void;
 }
 
 export const useNotificationStore = create<NotificationState>()((set, get) => ({
@@ -62,7 +64,6 @@ export const useNotificationStore = create<NotificationState>()((set, get) => ({
   },
 
   markAsRead: async (id: string) => {
-    // Optimistic update
     set((state) => ({
       notifications: state.notifications.map((n) =>
         n.id === id ? { ...n, isRead: true } : n
@@ -76,7 +77,6 @@ export const useNotificationStore = create<NotificationState>()((set, get) => ({
   },
 
   markAllAsRead: async () => {
-    // Optimistic update
     set((state) => ({
       notifications: state.notifications.map((n) => ({ ...n, isRead: true })),
       unreadCount: 0,
@@ -85,5 +85,15 @@ export const useNotificationStore = create<NotificationState>()((set, get) => ({
     set({ isMutating: true });
     await markAllNotificationsRead();
     set({ isMutating: false });
+  },
+
+  pushNotification: (notification: Notification) => {
+    set((state) => ({
+      notifications: [notification, ...state.notifications],
+    }));
+  },
+
+  incrementUnread: () => {
+    set((state) => ({ unreadCount: state.unreadCount + 1 }));
   },
 }));


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 
Feat: Real-time notification delivery via SSE

## 🛠️ Issue

- Closes #141

## 📚 Description

Implements real-time notification delivery using Server-Sent Events (SSE). When the backend pushes a `new_notification` event, it is prepended to the Zustand notification store and displayed as a toast in the top-right corner. The SSE connection uses exponential backoff (1s → 30s) and reconnects automatically on tab visibility change.

## ✅ Changes applied

- `src/hooks/use-notification-sse.ts` — new hook that opens an SSE connection to `GET /notifications/stream?token=`, handles `new_notification` and `notification_read` events, reconnects with exponential backoff
- `src/stores/notification-store.ts` — added `pushNotification` and `incrementUnread` actions
- `src/components/notifications/NotificationToast.tsx` — neumorphic toast with 4s auto-dismiss and CSS enter/exit animation
- `src/components/notifications/NotificationToastContainer.tsx` — mounts the SSE hook, subscribes to the store to detect new arrivals, stacks up to 5 toasts
- `src/components/app-shell/AppLayoutClient.tsx` — renders `<NotificationToastContainer />` globally inside the app layout

## 🔍 Evidence/Media (screenshots/videos)

-