### PR TITLE
Fix/portfolio hydration and validation

### DIFF
--- a/src/components/portfolio/ImageUploader.tsx
+++ b/src/components/portfolio/ImageUploader.tsx
@@ -220,10 +220,10 @@ export function ImageUploader({
         </div>
       )}
 
-      {error && (
+      {localError && (
         <p className="text-sm text-error flex items-start gap-1.5">
           <Icon path={ICON_PATHS.alertCircle} size="sm" className="shrink-0 mt-0.5" />
-          {error}
+          {localError}
         </p>
       )}
     </div>

--- a/src/components/portfolio/PortfolioForm.tsx
+++ b/src/components/portfolio/PortfolioForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, KeyboardEvent } from "react";
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
 import { useAuthStore } from "@/stores/auth-store";
@@ -69,6 +69,10 @@ export function validatePortfolioForm(data: PortfolioFormData): PortfolioFormErr
 
   if (data.startDate && data.endDate && data.endDate < data.startDate) {
     errors.endDate = "End date must be after start date";
+  }
+
+  if (!data.images || data.images.length === 0) {
+    errors.images = "At least one image is required";
   }
 
   return errors;
@@ -276,7 +280,11 @@ export function PortfolioForm({
   const [formData, setFormData] = useState<PortfolioFormData>(initialData);
   const [errors, setErrors] = useState<PortfolioFormErrors>({});
   const [showPreview, setShowPreview] = useState(false);
-  const [activeTip] = useState(() => Math.floor(Math.random() * PORTFOLIO_TIPS.length));
+  const [activeTip, setActiveTip] = useState(0);
+
+  useEffect(() => {
+    setActiveTip(Math.floor(Math.random() * PORTFOLIO_TIPS.length));
+  }, []);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -480,6 +488,7 @@ export function PortfolioForm({
           {/* Images */}
           <FormField
             label="Images"
+            required
             hint={`${formData.images.length}/${MAX_IMAGES_PER_ITEM} · drag to reorder`}
             error={errors.images}
           >


### PR DESCRIPTION
# PR Description: Fix Portfolio Hydration Mismatch & Enforce Mandatory Images

## Description
This pull request addresses two main issues on the freelancer portfolio creation page:
1. **Hydration Mismatch**: Resolves the SSR/Client rendering conflict in the portfolio tip banner (`PORTFOLIO_TIPS`).
2. **Image Validation**: Makes project images mandatory during creation, ensuring freelancers showcase their work.

---

## Changes

### 🔧 Hydration Mismatch Resolution
* **Location**: `src/components/portfolio/PortfolioForm.tsx`
* **Details**: Previously, the `activeTip` state was initialized randomly using `Math.random()` during server-side rendering (SSR), resulting in client-server content mismatches during hydration. 
* **Fix**: Initialized `activeTip` with a static value (`0`) on initial render and used `useEffect` to safely randomize the selected tip index on the client side after mount.

### 🖼️ Mandatory Portfolio Images
* **Location**: `src/components/portfolio/PortfolioForm.tsx` & `src/components/portfolio/ImageUploader.tsx`
* **Details**: 
  * Updated the frontend validation logic (`validatePortfolioForm`) to require at least one image (`data.images.length > 0`). If missing, it blocks submission with the error `"At least one image is required"`.
  * Added the `required` visual indicator (`*`) to the Images form field label.
  * Refactored `ImageUploader.tsx` to display only the `localError` (such as file-size or upload API errors) inside the dropzone area. This keeps the error validation text from duplicating with the wrapper `FormField` error text while retaining the correct error highlights (red dashed border and background).

---

## Verification Results
* The frontend project compiled and built successfully:
  ```bash
  ✓ Compiled successfully in 2.8s
  ✓ Finished TypeScript in 3.7s
  ```
