### PR TITLE
fix(analytics): switch dashboard metrics to /analytics/* endpoints

### DIFF
--- a/src/lib/api/analytics.ts
+++ b/src/lib/api/analytics.ts
@@ -5,6 +5,154 @@ import type { ProfileViewsAnalytics } from "@/types/profile-views.types";
 
 const API_BASE_URL = API_URL;
 
+export interface MonthlyAnalyticsMetric {
+  currentMonth: string;
+  previousMonth: string;
+  changePercent: number | null;
+  currency?: string;
+}
+
+export interface BalanceHistoryPoint {
+  label: string;
+  earnings: number;
+  spending: number;
+}
+
+function extractData<T>(json: unknown): T {
+  if (json && typeof json === "object" && "data" in json && json.data !== undefined) {
+    return (json as { data: T }).data;
+  }
+  return json as T;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function toMoneyString(value: unknown): string {
+  return toNumber(value, 0).toFixed(2);
+}
+
+function toOptionalPercent(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = toNumber(value, Number.NaN);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveValue(source: Record<string, unknown>, keys: string[], fallback: unknown = 0): unknown {
+  for (const key of keys) {
+    if (source[key] !== undefined && source[key] !== null) return source[key];
+  }
+  return fallback;
+}
+
+function normalizeMetric(payload: unknown): MonthlyAnalyticsMetric {
+  const obj = (payload && typeof payload === "object" ? payload : {}) as Record<string, unknown>;
+
+  const currentMonth = resolveValue(obj, [
+    "currentMonth",
+    "currentMonthEarnings",
+    "currentMonthSpending",
+    "thisMonth",
+    "monthly",
+    "value",
+    "amount",
+  ]);
+  const previousMonth = resolveValue(obj, [
+    "previousMonth",
+    "previousMonthEarnings",
+    "previousMonthSpending",
+    "lastMonth",
+    "previous",
+    "previousValue",
+  ]);
+  const changePercent = resolveValue(obj, [
+    "changePercent",
+    "percentageChange",
+    "percentChange",
+    "monthOverMonthPercent",
+  ], null);
+  const currency = resolveValue(obj, ["currency", "currencyCode"], undefined);
+
+  return {
+    currentMonth: toMoneyString(currentMonth),
+    previousMonth: toMoneyString(previousMonth),
+    changePercent: toOptionalPercent(changePercent),
+    currency: typeof currency === "string" ? currency : undefined,
+  };
+}
+
+async function fetchAnalyticsMetric(
+  token: string,
+  endpoint: "earnings" | "spending"
+): Promise<MonthlyAnalyticsMetric> {
+  const response = await fetch(`${API_BASE_URL}/analytics/${endpoint}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load analytics ${endpoint}`);
+  }
+
+  const json = await response.json();
+  return normalizeMetric(extractData<unknown>(json));
+}
+
+function normalizeBalanceHistory(payload: unknown): BalanceHistoryPoint[] {
+  const rows = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === "object" && Array.isArray((payload as { points?: unknown[] }).points)
+      ? (payload as { points: unknown[] }).points
+      : [];
+
+  return rows.map((row, index) => {
+    const point = (row && typeof row === "object" ? row : {}) as Record<string, unknown>;
+    const fallbackLabel = `Period ${index + 1}`;
+
+    return {
+      label:
+        (typeof point.label === "string" && point.label) ||
+        (typeof point.month === "string" && point.month) ||
+        (typeof point.period === "string" && point.period) ||
+        fallbackLabel,
+      earnings: toNumber(resolveValue(point, ["earnings", "income", "credits"], 0), 0),
+      spending: toNumber(resolveValue(point, ["spending", "expenses", "debits"], 0), 0),
+    };
+  });
+}
+
+export async function getEarningsAnalytics(token: string): Promise<MonthlyAnalyticsMetric> {
+  return fetchAnalyticsMetric(token, "earnings");
+}
+
+export async function getSpendingAnalytics(token: string): Promise<MonthlyAnalyticsMetric> {
+  return fetchAnalyticsMetric(token, "spending");
+}
+
+export async function getBalanceHistoryAnalytics(token: string): Promise<BalanceHistoryPoint[]> {
+  const response = await fetch(`${API_BASE_URL}/analytics/balance-history`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to load analytics balance history");
+  }
+
+  const json = await response.json();
+  return normalizeBalanceHistory(extractData<unknown>(json));
+}
+
 /**
  * Fetch profile views analytics for the authenticated freelancer.
  *

--- a/src/lib/api/freelancer.ts
+++ b/src/lib/api/freelancer.ts
@@ -1,7 +1,15 @@
 import { API_URL } from "@/config/api";
+import { getEarningsAnalytics } from "@/lib/api/analytics";
 import type { DashboardStats } from "@/types/freelancer-dashboard.types";
 
 const API_BASE_URL = API_URL;
+
+function formatCurrencyValue(value: unknown): string {
+  if (typeof value === "string" && value.includes("$")) return value;
+  const numeric = typeof value === "number" ? value : Number.parseFloat(String(value ?? 0));
+  const safe = Number.isFinite(numeric) ? numeric : 0;
+  return `$${safe.toFixed(2)}`;
+}
 
 export interface FreelancerStats {
   activeServices: number;
@@ -38,29 +46,42 @@ export async function getFreelancerStats(token: string): Promise<FreelancerStats
 }
 
 export async function getDashboardStats(token: string): Promise<DashboardStats> {
-  const response = await fetch(`${API_BASE_URL}/freelancer/dashboard/stats`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  });
+  const [dashboardRes, earningsRes] = await Promise.allSettled([
+    fetch(`${API_BASE_URL}/freelancer/dashboard/stats`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }),
+    getEarningsAnalytics(token),
+  ]);
 
-  if (!response.ok) {
+  let dashboardData: { stats: Record<string, unknown>; comparison?: Record<string, unknown> } | null = null;
+  if (dashboardRes.status === "fulfilled" && dashboardRes.value.ok) {
+    const body = await dashboardRes.value.json();
+    dashboardData = body.data;
+  }
+
+  if (!dashboardData && earningsRes.status !== "fulfilled") {
     throw new Error('Failed to fetch dashboard stats');
   }
 
-  const body = await response.json();
-  const { stats, comparison } = body.data;
+  const stats = dashboardData?.stats ?? {};
+  const comparison = dashboardData?.comparison as { earnings?: { changePercent?: number | null } } | undefined;
+
+  const earningsFromAnalytics = earningsRes.status === "fulfilled" ? earningsRes.value : null;
 
   return {
-    activeApplications: stats.activeApplications,
-    activeOrders: stats.ordersInProgress,
-    totalEarnings: stats.earningsThisMonth,
-    rating: stats.averageRating !== null ? parseFloat(stats.averageRating) : null,
+    activeApplications: Number(stats.activeApplications ?? 0),
+    activeOrders: Number(stats.ordersInProgress ?? 0),
+    totalEarnings: formatCurrencyValue(
+      earningsFromAnalytics?.currentMonth ?? String(stats.earningsThisMonth ?? "0.00")
+    ),
+    rating: stats.averageRating !== null && stats.averageRating !== undefined ? parseFloat(String(stats.averageRating)) : null,
     ratingCount: 0,
     activeApplicationsTrend: null,
     activeOrdersTrend: null,
-    earningsTrend: comparison?.earnings?.changePercent ?? null,
+    earningsTrend: earningsFromAnalytics?.changePercent ?? comparison?.earnings?.changePercent ?? null,
     ratingTrend: null,
   };
 }

--- a/src/lib/api/wallet.ts
+++ b/src/lib/api/wallet.ts
@@ -1,4 +1,9 @@
 import { API_URL } from "@/config/api";
+import {
+  getBalanceHistoryAnalytics,
+  getEarningsAnalytics,
+  getSpendingAnalytics,
+} from "@/lib/api/analytics";
 
 export interface WalletBalance {
   currency: string;
@@ -300,7 +305,31 @@ export async function getWalletDashboard(token: string): Promise<WalletDashboard
   }
 
   const json = (await response.json()) as { data: WalletDashboardData };
-  return json.data;
+  const data = json.data;
+
+  // Wallet dashboard still provides balance/withdrawals/transactions while
+  // analytics endpoints provide monthly metrics + history chart.
+  const [earningsRes, spendingRes, historyRes] = await Promise.allSettled([
+    getEarningsAnalytics(token),
+    getSpendingAnalytics(token),
+    getBalanceHistoryAnalytics(token),
+  ]);
+
+  if (earningsRes.status === "fulfilled") {
+    data.monthly.currentMonthEarnings = earningsRes.value.currentMonth;
+    data.monthly.previousMonthEarnings = earningsRes.value.previousMonth;
+  }
+
+  if (spendingRes.status === "fulfilled") {
+    data.monthly.currentMonthSpending = spendingRes.value.currentMonth;
+    data.monthly.previousMonthSpending = spendingRes.value.previousMonth;
+  }
+
+  if (historyRes.status === "fulfilled" && historyRes.value.length > 0) {
+    data.chart = historyRes.value;
+  }
+
+  return data;
 }
 
 export async function createWithdrawalRequest(


### PR DESCRIPTION
Issue #213 
Adds frontend support for the new analytics endpoints:
GET /analytics/earnings
GET /analytics/spending
GET /analytics/balance-history
Updates wallet dashboard data loading so monthly earnings/spending cards and the cash-flow chart use analytics data instead of staying on static/fallback values.
Updates freelancer dashboard stats loading so the Total Earnings card and earnings trend are populated from analytics data when available.
Keeps safe fallback behavior to existing dashboard/wallet responses so pages still render if one of the analytics endpoints is temporarily unavailable.
What Changed
src/lib/api/analytics.ts
Added typed analytics client methods for earnings, spending, and balance history.
Added response normalization utilities to handle small backend shape differences during rollout.
src/lib/api/wallet.ts
getWalletDashboard() now enriches wallet data with analytics earnings, spending, and balance-history data.
Existing wallet dashboard response remains the base source for balance, withdrawals, and transactions.
src/lib/api/freelancer.ts
getDashboardStats() now fetches earnings analytics in parallel with dashboard stats.
Maps analytics values into totalEarnings and earningsTrend with graceful fallback if analytics fails.
Acceptance Criteria Coverage
Analytics client calls /analytics/earnings and reads monthly earnings + percent change.
Analytics client calls /analytics/spending and reads monthly spending + percent change.
Analytics client calls /analytics/balance-history and maps time-series points for wallet chart rendering.
Wallet dashboard stat cards now show live monthly analytics values where available.
Freelancer dashboard Total Earnings stat card now reflects analytics-backed data instead of hardcoded/zero fallback.
Testing Notes
Manual verification recommended on a freelancer account with wallet activity:
Confirm all three /analytics/* calls return 200 in Network tab.
Confirm wallet “Earned this month”, “Withdrawn this month”, and cash-flow chart match analytics responses.
Confirm freelancer dashboard “Total Earnings” and trend match /analytics/earnings.
Regression/fallback check:
Temporarily fail one analytics endpoint and verify dashboard pages still load with fallback values.