### PR TITLE
feat(chat): implement POST /conversations and complete chat API client (#210)

### DIFF
--- a/src/lib/api/chat.ts
+++ b/src/lib/api/chat.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   Conversation,
   ConversationsResponse,
+  CreateConversationPayload,
   MessagesResponse,
 } from "@/types/chat.types";
 
@@ -23,6 +24,17 @@ export async function getConversations(
   return httpGet<ConversationsResponse>(BASE, {
     params: cursor ? { cursor, limit: "20" } : { limit: "20" },
   });
+}
+
+/**
+ * Create a new conversation with another user.
+ * Returns the newly created conversation, or an existing one if it already
+ * exists between the two participants (backend deduplication).
+ */
+export async function createConversation(
+  payload: CreateConversationPayload
+): Promise<ApiResponse<Conversation>> {
+  return httpPost<Conversation>(BASE, payload);
 }
 
 /**

--- a/src/types/chat.types.ts
+++ b/src/types/chat.types.ts
@@ -111,3 +111,10 @@ export interface MessagesResponse {
   hasMore: boolean;
   nextCursor?: string;
 }
+
+// ─── Request payloads ───────────────────────────────────────────────────────
+
+export interface CreateConversationPayload {
+  /** ID of the user to start a conversation with. */
+  participantId: string;
+}


### PR DESCRIPTION
## Summary

Closes #210

Completes the chat API client by implementing the missing
`POST /conversations` endpoint, which was listed in the acceptance
criteria for #210 but was never added to the codebase.

## Changes

### `src/lib/api/chat.ts`
- Added `createConversation(payload)` — calls `POST /conversations`
- Returns the new (or existing deduplicated) `Conversation` object

### `src/types/chat.types.ts`
- Added `CreateConversationPayload` interface (`{ participantId: string }`)
- Added `// ─── Request payloads ───` section for future payload types

## All acceptance criteria now met

| Criterion | Status |
|---|---|
| Chat API base path = `/conversations` | ✅ Already in `main` |
| `GET /conversations` (list) | ✅ `getConversations()` |
| `POST /conversations` (create) | ✅ `createConversation()` — **added in this PR** |
| `GET /conversations/:id/messages` | ✅ `getMessages()` |
| SSE stream `/conversations/:id/stream` | ✅ `getChatSSEUrl()` |
| No mock fallbacks in API client | ✅ Confirmed |

## Validation
- ✅ ESLint — 0 errors, 0 warnings
- ✅ TypeScript types consistent with existing patterns
- Related: OFFER-HUB-API#76
