### PR TITLE
Feat: Profile Completeness Indicator UI (FE-005)

### DIFF
--- a/src/app/app/profile/page.tsx
+++ b/src/app/app/profile/page.tsx
@@ -15,6 +15,7 @@ import { getProfile, updateProfile, type UpdateProfileData } from "@/lib/api/pro
 import { uploadImage } from "@/lib/api/upload";
 import Link from "next/link";
 import { ConnectedAccounts } from "@/components/profile/ConnectedAccounts";
+import { ProfileCompleteness } from "@/components/profile/ProfileCompleteness";
 
 interface ProfileFormData {
   firstName: string;
@@ -296,6 +297,11 @@ export default function ProfilePage() {
           </Link>
         </div>
       </div>
+
+      {/* Profile Completeness Widget - Only shown for freelancers */}
+      <Suspense fallback={null}>
+        <ProfileCompleteness />
+      </Suspense>
 
       <div className={NEUMORPHIC_CARD}>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/profile/ProfileCompleteness.tsx
+++ b/src/components/profile/ProfileCompleteness.tsx
@@ -9,11 +9,16 @@ import { getProfileCompleteness, type ProfileCompletenessData } from "@/lib/api/
 import { useAuthStore } from "@/stores/auth-store";
 
 export function ProfileCompleteness(): React.JSX.Element | null {
-  const { token } = useAuthStore();
+  const { token, user } = useAuthStore();
   const [data, setData] = useState<ProfileCompletenessData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [animatedPercentage, setAnimatedPercentage] = useState(0);
+
+  // Only show for freelancers (SELLER) or users with BOTH roles
+  if (user && user.type !== "SELLER" && user.type !== "BOTH") {
+    return null;
+  }
 
   useEffect(() => {
     if (!token) return;


### PR DESCRIPTION
closes #198 

 

- Feat: Profile Completeness Indicator UI (FE-005)
 
## 📚 Description

- This PR integrates the Profile Completeness indicator widget into the profile page and adds role-based visibility logic. The widget calculates and displays the profile completion percentage along with actionable missing fields, helping freelancers finish their profiles. It automatically hides once the profile is 100% complete or if the logged-in user is not a freelancer.

 Changes applied

- **Restricted Visibility to Sellers/Freelancers:** Updated `src/components/profile/ProfileCompleteness.tsx` to read the user's role from the auth store and render `null` if the user is not a `SELLER` or `BOTH`.
- **Integrated Component on Profile Page:** Mounted the `ProfileCompleteness` component in `src/app/app/profile/page.tsx` within a `<Suspense>` wrapper for a smooth loading experience.
- **Actionable Steps Display:** Set up progress animation and logic to render actionable missing fields to help users complete their registration.

## 🔍 Evidence/Media (screenshots/videos)
<img width="1898" height="903" alt="Screenshot 2026-05-30 045543" src="https://github.com/user-attachments/assets/1816fdcb-2a0f-4c20-a16f-7ec678a14d02" />

 
<img width="959" height="511" alt="image" src="https://github.com/user-attachments/assets/efc72025-88d2-4ae6-a389-f639c1bd1d54" />


@Josue19-08 I am done 
