### PR TITLE
feat: add informational cards to create offer and create service pages

### DIFF
--- a/src/app/app/client/offers/new/page.tsx
+++ b/src/app/app/client/offers/new/page.tsx
@@ -170,6 +170,40 @@ export default function CreateOfferPage(): React.JSX.Element {
         </div>
       </div>
 
+      <div className={cn(NEUMORPHIC_CARD, "p-5 border-l-4 border-primary")}>
+        <div className="flex flex-col md:flex-row md:items-center gap-6">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2 text-primary">
+              <Icon path={ICON_PATHS.infoCircle} size="md" className="text-primary shrink-0" />
+              <h2 className="text-base font-bold text-text-primary">What is an Offer?</h2>
+            </div>
+            <p className="text-xs text-text-secondary leading-relaxed max-w-xl">
+              An offer is a job post where you describe a task or project you need completed. Freelancers will browse your offer and apply with a proposal. You review applicants and choose who to hire.
+            </p>
+          </div>
+          <div className="w-full md:w-auto shrink-0 border-t md:border-t-0 md:border-l border-border-light/80 pt-4 md:pt-0 md:pl-6 space-y-2">
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.document} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Describe the task clearly</strong> — title, description, budget, and deadline
+              </span>
+            </div>
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.users} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Receive proposals</strong> from qualified freelancers
+              </span>
+            </div>
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.check} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Accept the best proposal</strong> and start the project
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <form onSubmit={handleSubmit}>
         <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
           <div className="xl:col-span-2 space-y-6">

--- a/src/app/app/freelancer/services/new/page.tsx
+++ b/src/app/app/freelancer/services/new/page.tsx
@@ -160,6 +160,40 @@ export default function CreateServicePage(): React.JSX.Element {
         </div>
       </div>
 
+      <div className={cn(NEUMORPHIC_CARD, "p-5 border-l-4 border-primary")}>
+        <div className="flex flex-col md:flex-row md:items-center gap-6">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2 text-primary">
+              <Icon path={ICON_PATHS.infoCircle} size="md" className="text-primary shrink-0" />
+              <h2 className="text-base font-bold text-text-primary">What is a Service?</h2>
+            </div>
+            <p className="text-xs text-text-secondary leading-relaxed max-w-xl">
+              A service is something you offer to clients. Clients browse the marketplace and can hire you directly based on your service listing. Set your price, describe what you deliver, and start getting hired.
+            </p>
+          </div>
+          <div className="w-full md:w-auto shrink-0 border-t md:border-t-0 md:border-l border-border-light/80 pt-4 md:pt-0 md:pl-6 space-y-2">
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.briefcase} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Define what you deliver</strong> — title, description, category, and price
+              </span>
+            </div>
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.search} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Clients discover</strong> your service in the marketplace
+              </span>
+            </div>
+            <div className="flex items-center gap-2.5 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.check} size="sm" className="text-primary shrink-0" />
+              <span>
+                <strong className="text-text-primary">Get hired directly</strong> without waiting for applications
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div className={NEUMORPHIC_CARD}>
         <form onSubmit={handleSubmit} className="space-y-5">
           <FormField label="Service Title" required error={errors.title}>


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
feat: add informational cards to create offer and create service pages

## 🛠️ Issue
- No linked issue (UX improvement)

## 📚 Description
Adds a compact neumorphic info card above the form on both the Create Offer and Create Service pages. The card explains what each concept is and what the user should expect, helping new users understand the difference before filling out the form.

## ✅ Changes applied
- `src/app/app/client/offers/new/page.tsx`: added "What is an Offer?" card with 3 bullet points (describe task, receive proposals, accept best proposal)
- `src/app/app/freelancer/services/new/page.tsx`: added "What is a Service?" card with 3 bullet points (define what you deliver, clients discover it, get hired directly)
- Both cards use `NEUMORPHIC_CARD` + `border-l-4 border-primary`, `Icon` + `ICON_PATHS`, no new dependencies

## 🔍 Evidence/Media
- TypeScript: no errors
- No new dependencies added