### PR TITLE
fix: refresh backend JWT via API

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { API_URL } from "@/config/api";
 import {
   buildSecureCookie,
   buildDeleteCookie,
@@ -19,22 +20,27 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    // TODO: Replace with actual backend API call
-    // const backendResponse = await fetch(`${process.env.API_URL}/auth/refresh`, {
-    //   method: "POST",
-    //   headers: { "Content-Type": "application/json" },
-    //   body: JSON.stringify({ refreshToken }),
-    // });
-    //
-    // if (!backendResponse.ok) {
-    //   throw new Error("Token refresh failed");
-    // }
-    //
-    // const { token, refreshToken: newRefreshToken } = await backendResponse.json();
+    const backendResponse = await fetch(`${API_URL}/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
 
-    // For now, simulate token refresh (remove in production)
-    const token = `refreshed-token-${Date.now()}`;
-    const newRefreshToken = `new-refresh-token-${Date.now()}`;
+    const backendData = await backendResponse.json();
+
+    if (!backendResponse.ok) {
+      throw new Error(
+        backendData.error?.message || backendData.message || "Token refresh failed"
+      );
+    }
+
+    const data = backendData.data || backendData;
+    const token = data.token;
+    const newRefreshToken = data.refreshToken || refreshToken;
+
+    if (!token) {
+      throw new Error("Backend did not return a refreshed token");
+    }
 
     const response = NextResponse.json({ success: true });
 


### PR DESCRIPTION
## Summary
Connect NextAuth refresh flow to the backend refresh endpoint instead of using simulated tokens.

## Changes Made
- Removed simulated token refresh behavior
- Added backend refresh API integration
- Updated refresh flow to store returned auth and refresh tokens in cookies
- Added error handling for failed refresh attempts

## Testing
- Verified project builds successfully
- Verified refresh route calls backend endpoint
- Confirmed refreshed tokens are written to cookies

Closes #209