### PR TITLE
fix: guard against undefined monthly field on wallet page crash

### DIFF
--- a/src/lib/api/wallet.ts
+++ b/src/lib/api/wallet.ts
@@ -173,8 +173,17 @@ export async function getWalletDashboard(token: string): Promise<WalletDashboard
   const json = (await response.json()) as { data: WalletDashboardData };
   const data = json.data;
 
-  // Wallet dashboard still provides balance/withdrawals/transactions while
-  // analytics endpoints provide monthly metrics + history chart.
+  // Ensure monthly always exists even if the API omits it
+  if (!data.monthly) {
+    data.monthly = {
+      currentMonthEarnings: "0.00",
+      previousMonthEarnings: "0.00",
+      currentMonthSpending: "0.00",
+      previousMonthSpending: "0.00",
+    };
+  }
+
+  // Enrich with analytics endpoints when available (404 = not yet deployed, skip silently)
   const [earningsRes, spendingRes, historyRes] = await Promise.allSettled([
     getEarningsAnalytics(token),
     getSpendingAnalytics(token),


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
fix: guard against undefined monthly field on wallet page crash

## 🛠️ Issue
- No linked issue (production crash fix)

## 📚 Description
The wallet page was crashing in production with `TypeError: Cannot read properties of undefined (reading 'currentMonthEarnings')` because the backend's `GET /wallet/dashboard` response does not include a `monthly` field, and the analytics endpoints (`/analytics/earnings`, `/analytics/spending`, `/analytics/balance-history`) return 404.

## ✅ Changes applied
- `src/lib/api/wallet.ts`: added null guard — if `data.monthly` is missing from the API response, initialize it with `"0.00"` defaults so the page renders instead of crashing. Analytics still enrich the values when their endpoints become available.

## 🔍 Evidence/Media
- Production error before fix: `TypeError: Cannot read properties of undefined (reading 'currentMonthEarnings')` at wallet page
- TypeScript: no errors