### PR TITLE
Feat/cloudinary offer attachments

### DIFF
--- a/src/app/app/client/offers/[id]/edit/page.tsx
+++ b/src/app/app/client/offers/[id]/edit/page.tsx
@@ -395,7 +395,9 @@ export default function EditOfferPage(): React.JSX.Element {
                   <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
                     {existingAttachments.map((attachment) => {
                       const isImage = attachment.mimeType.startsWith("image/");
-                      const fileUrl = `${backendUrl}${attachment.url}`;
+                      const fileUrl = attachment.url.startsWith("http")
+                        ? attachment.url
+                        : `${backendUrl}${attachment.url}`;
                       const isDeleting = deletingAttachmentId === attachment.id;
 
                       return (

--- a/src/app/app/client/offers/[id]/page.tsx
+++ b/src/app/app/client/offers/[id]/page.tsx
@@ -289,7 +289,9 @@ export default function OfferPanelPage(): React.JSX.Element {
                 {offer.apiAttachments.map((attachment) => {
                   const isImage = attachment.mimeType.startsWith("image/");
                   const backendUrl = BACKEND_URL;
-                  const fileUrl = `${backendUrl}${attachment.url}`;
+                  const fileUrl = attachment.url.startsWith("http")
+                    ? attachment.url
+                    : `${backendUrl}${attachment.url}`;
 
                   return (
                     <a

--- a/src/app/marketplace/offers/[id]/page.tsx
+++ b/src/app/marketplace/offers/[id]/page.tsx
@@ -204,7 +204,9 @@ export default function OfferDetailPage(): React.JSX.Element {
                 <h2 className="text-xl font-bold text-text-primary mb-4">Attachments</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {offer.attachments.map((attachment) => {
-                    const fileUrl = `${backendUrl}${attachment.url}`;
+                    const fileUrl = attachment.url.startsWith("http")
+                      ? attachment.url
+                      : `${backendUrl}${attachment.url}`;
                     const isImage = attachment.mimeType.startsWith("image/");
 
                     return (

--- a/src/components/marketplace/OfferCard.tsx
+++ b/src/components/marketplace/OfferCard.tsx
@@ -40,7 +40,11 @@ export function OfferCard({ offer, className, highlightQuery }: OfferCardProps):
   const imageAttachment = offer.attachments?.find((att) =>
     att.mimeType.startsWith("image/")
   );
-  const imageUrl = imageAttachment ? `${BACKEND_URL}${imageAttachment.url}` : null;
+  const imageUrl = imageAttachment
+    ? imageAttachment.url.startsWith("http")
+      ? imageAttachment.url
+      : `${BACKEND_URL}${imageAttachment.url}`
+    : null;
 
   return (
     <Link


### PR DESCRIPTION
# Description
This PR updates the frontend application to support absolute URLs for offer attachments (as returned by the updated Cloudinary storage api) while maintaining full backward-compatibility with existing relative `/uploads/offers` URLs.

## Key Changes
- **OfferCard.tsx**: Resolved the preview image URL using a conditional check. If the attachment's URL is absolute (starts with `http`), it is rendered directly; otherwise, it prepends `BACKEND_URL`.
- **Marketplace Offer Detail View (`/marketplace/offers/[id]`)**: Resolved the download/view file link dynamically.
- **Client Offer Detail View (`/app/client/offers/[id]`)**: Updated file URL construction to prevent prepending the backend URL to external Cloudinary links.
- **Client Offer Edit View (`/app/client/offers/[id]/edit`)**: Handled dynamic resolution for current attachments previews.

## How to Test
1. Start the frontend: `npm run dev`.
2. Navigate to the marketplace or client dashboard and check job offers with attachments.
3. Verify that cards render preview images correctly from Cloudinary absolute URLs.
4. Open the details page for an offer and confirm attachments open in new tabs successfully.
