### PR TITLE
fix: uniform card layout with animated gradient placeholder for missing images

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,6 +202,15 @@ html:has(.app-no-scroll) body {
 }
 
 /* Custom animations */
+@keyframes shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 100% 50%;
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -399,6 +408,11 @@ html:has(.app-no-scroll) body {
 
 .animate-slide-up {
   animation: slideUp 0.4s ease-out forwards;
+}
+
+.animate-shimmer {
+  background-size: 200% 200%;
+  animation: shimmer 4s ease-in-out infinite alternate;
 }
 
 /* 404 Page - Lamp animations */

--- a/src/components/marketplace/OfferCard.tsx
+++ b/src/components/marketplace/OfferCard.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
-import { BACKEND_URL } from "@/config/api";
 import type { MarketplaceOffer } from "@/lib/api/marketplace";
 import { HighlightedText } from "@/components/search/HighlightedText";
 
@@ -25,6 +24,18 @@ const CATEGORY_MAP: Record<string, string> = {
   OTHER: "Other",
 };
 
+const CATEGORY_GRADIENTS: Record<string, string> = {
+  WEB_DEVELOPMENT: "from-blue-400 to-indigo-600",
+  MOBILE_DEVELOPMENT: "from-violet-400 to-purple-600",
+  DESIGN: "from-pink-400 to-rose-600",
+  WRITING: "from-amber-400 to-orange-500",
+  MARKETING: "from-green-400 to-emerald-600",
+  VIDEO: "from-red-400 to-rose-600",
+  MUSIC: "from-cyan-400 to-teal-600",
+  DATA: "from-sky-400 to-blue-600",
+  OTHER: "from-gray-400 to-slate-600",
+};
+
 export function OfferCard({ offer, className, highlightQuery }: OfferCardProps): React.JSX.Element {
   const budget = parseFloat(offer.budget);
   const deadline = new Date(offer.deadline).toLocaleDateString("en-US", {
@@ -33,46 +44,55 @@ export function OfferCard({ offer, className, highlightQuery }: OfferCardProps):
     year: "numeric",
   });
   const category = CATEGORY_MAP[offer.category] || offer.category;
-  // Extract display name from email
   const userName = offer.user?.email?.split("@")[0] || "Anonymous";
 
-  // Find first image attachment
+  // Only use absolute Cloudinary URLs — /uploads/... paths are broken (ephemeral Railway disk)
   const imageAttachment = offer.attachments?.find((att) =>
     att.mimeType.startsWith("image/")
   );
-  const imageUrl = imageAttachment
-    ? imageAttachment.url.startsWith("http")
-      ? imageAttachment.url
-      : `${BACKEND_URL}${imageAttachment.url}`
-    : null;
+  const rawUrl = imageAttachment?.url ?? null;
+  const imageUrl = rawUrl?.startsWith("https://") ? rawUrl : null;
 
   return (
     <Link
       href={`/marketplace/offers/${offer.id}`}
       className={cn(
-        "block rounded-xl transition-all duration-200 overflow-hidden",
+        "flex flex-col h-full rounded-xl transition-all duration-200 overflow-hidden",
         "bg-background shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
         "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
         "hover:scale-[1.01]",
         className
       )}
     >
-      {/* Image Preview */}
-      {imageUrl && (
-        <div className="w-full h-48 overflow-hidden bg-gray-100">
+      {/* Image / Gradient Placeholder — always h-44 */}
+      <div className="relative w-full h-44 overflow-hidden bg-gray-100 flex-shrink-0">
+        {imageUrl ? (
           <img
             src={imageUrl}
             alt={offer.title}
             className="w-full h-full object-cover"
           />
-        </div>
-      )}
+        ) : (
+          <div
+            className={cn(
+              "w-full h-full bg-gradient-to-br animate-shimmer flex items-center justify-center",
+              CATEGORY_GRADIENTS[offer.category] || CATEGORY_GRADIENTS.OTHER
+            )}
+          >
+            <Icon
+              path={ICON_PATHS.image}
+              size="lg"
+              className="text-white opacity-40"
+            />
+          </div>
+        )}
+      </div>
 
       {/* Content */}
-      <div className="p-6">
+      <div className="p-4 flex flex-col flex-grow">
         {/* Client Info */}
         <div className="flex items-center gap-3 mb-3">
-          <div className="w-10 h-10 rounded-full bg-primary text-white flex items-center justify-center font-semibold">
+          <div className="w-10 h-10 rounded-full bg-primary text-white flex items-center justify-center font-semibold flex-shrink-0">
             {userName.charAt(0).toUpperCase()}
           </div>
           <div className="flex-1 min-w-0">
@@ -81,51 +101,51 @@ export function OfferCard({ offer, className, highlightQuery }: OfferCardProps):
           </div>
         </div>
 
-      {/* Title */}
-      <h3 className="text-lg font-semibold text-text-primary mb-2 line-clamp-2">
-        {highlightQuery ? (
-          <HighlightedText text={offer.title} query={highlightQuery} />
-        ) : (
-          offer.title
-        )}
-      </h3>
+        {/* Title */}
+        <h3 className="text-lg font-semibold text-text-primary mb-2 line-clamp-2">
+          {highlightQuery ? (
+            <HighlightedText text={offer.title} query={highlightQuery} />
+          ) : (
+            offer.title
+          )}
+        </h3>
 
-      {/* Description */}
-      <p className="text-sm text-text-secondary mb-4 line-clamp-3">
-        {highlightQuery ? (
-          <HighlightedText text={offer.description} query={highlightQuery} />
-        ) : (
-          offer.description
-        )}
-      </p>
+        {/* Description */}
+        <p className="text-sm text-text-secondary mb-4 line-clamp-2">
+          {highlightQuery ? (
+            <HighlightedText text={offer.description} query={highlightQuery} />
+          ) : (
+            offer.description
+          )}
+        </p>
 
-      {/* Details */}
-      <div className="flex items-center justify-between pt-4 border-t border-border-light">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-1 text-primary">
-            <Icon path={ICON_PATHS.currency} size="sm" />
-            <span className="font-semibold">${budget.toLocaleString()}</span>
+        {/* Footer — pinned to bottom */}
+        <div className="mt-auto">
+          <div className="flex items-center justify-between pt-4 border-t border-border-light">
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1 text-primary">
+                <Icon path={ICON_PATHS.currency} size="sm" />
+                <span className="font-semibold">${budget.toLocaleString()}</span>
+              </div>
+              <div className="flex items-center gap-1 text-text-secondary">
+                <Icon path={ICON_PATHS.clock} size="sm" />
+                <span className="text-sm">{deadline}</span>
+              </div>
+            </div>
+            {offer.attachments && offer.attachments.length > 0 && (
+              <div className="flex items-center gap-1 text-text-secondary">
+                <Icon path={ICON_PATHS.image} size="sm" />
+                <span className="text-xs">{offer.attachments.length}</span>
+              </div>
+            )}
           </div>
-          <div className="flex items-center gap-1 text-text-secondary">
-            <Icon path={ICON_PATHS.clock} size="sm" />
-            <span className="text-sm">{deadline}</span>
-          </div>
+          {offer.applicantsCount > 0 && (
+            <div className="mt-3 flex items-center gap-1 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.users} size="sm" />
+              <span>{offer.applicantsCount} applicant{offer.applicantsCount !== 1 ? "s" : ""}</span>
+            </div>
+          )}
         </div>
-        {offer.attachments && offer.attachments.length > 0 && (
-          <div className="flex items-center gap-1 text-text-secondary">
-            <Icon path={ICON_PATHS.image} size="sm" />
-            <span className="text-xs">{offer.attachments.length}</span>
-          </div>
-        )}
-      </div>
-
-      {/* Applicants count */}
-      {offer.applicantsCount > 0 && (
-        <div className="mt-3 flex items-center gap-1 text-xs text-text-secondary">
-          <Icon path={ICON_PATHS.users} size="sm" />
-          <span>{offer.applicantsCount} applicant{offer.applicantsCount !== 1 ? "s" : ""}</span>
-        </div>
-      )}
       </div>
     </Link>
   );

--- a/src/components/marketplace/ServiceCard.tsx
+++ b/src/components/marketplace/ServiceCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 import type { MarketplaceService } from "@/lib/api/marketplace";
@@ -25,6 +24,18 @@ const CATEGORY_MAP: Record<string, string> = {
   OTHER: "Other",
 };
 
+const CATEGORY_GRADIENTS: Record<string, string> = {
+  WEB_DEVELOPMENT: "from-blue-400 to-indigo-600",
+  MOBILE_DEVELOPMENT: "from-violet-400 to-purple-600",
+  DESIGN: "from-pink-400 to-rose-600",
+  WRITING: "from-amber-400 to-orange-500",
+  MARKETING: "from-green-400 to-emerald-600",
+  VIDEO: "from-red-400 to-rose-600",
+  MUSIC: "from-cyan-400 to-teal-600",
+  DATA: "from-sky-400 to-blue-600",
+  OTHER: "from-gray-400 to-slate-600",
+};
+
 export function ServiceCard({ service, className, highlightQuery }: ServiceCardProps): React.JSX.Element {
   const price = parseFloat(service.price);
   const category = CATEGORY_MAP[service.category] || service.category;
@@ -44,7 +55,7 @@ export function ServiceCard({ service, className, highlightQuery }: ServiceCardP
     <Link
       href={`/marketplace/services/${service.id}`}
       className={cn(
-        "group block p-6 rounded-3xl transition-all duration-300",
+        "group flex flex-col h-full rounded-3xl transition-all duration-300 overflow-hidden",
         "bg-background",
         "shadow-[8px_8px_16px_#d1d5db,-8px_-8px_16px_#ffffff]",
         "hover:shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
@@ -52,137 +63,149 @@ export function ServiceCard({ service, className, highlightQuery }: ServiceCardP
         className
       )}
     >
-      {/* Freelancer Header */}
-      <div className="flex items-start gap-4 mb-6">
-        <div className="relative shrink-0">
-          <div className={cn(
-            "w-16 h-16 rounded-2xl overflow-hidden transition-all duration-300",
-            "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
-            "group-hover:shadow-[inset_1px_1px_2px_#d1d5db,inset_-1px_-1px_2px_#ffffff]"
-          )}>
-            {service.user?.avatarUrl ? (
-              <Image
-                src={service.user.avatarUrl}
-                alt={displayName}
-                width={64}
-                height={64}
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full bg-background shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff] text-primary flex items-center justify-center font-bold text-xl">
-                {initials.toUpperCase()}
-              </div>
-            )}
-          </div>
-          {service.status === "ACTIVE" && (
-            <div className="absolute -bottom-1 -right-1 w-5 h-5 bg-success rounded-full border-2 border-background shadow-sm" />
-          )}
-        </div>
-
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 mb-1">
-            <h3 className="font-bold text-text-primary text-lg truncate group-hover:text-primary transition-colors">
-              {displayName}
-            </h3>
-            <div className={cn(
-              "flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center",
-              "bg-success"
-            )}>
-              <Icon path={ICON_PATHS.check} size="sm" className="text-white" strokeWidth={3} />
-            </div>
-          </div>
-          <div className="flex items-center gap-2 mb-2">
-            <Icon path={ICON_PATHS.mapPin} size="sm" className="text-text-secondary flex-shrink-0" />
-            <span className="text-sm text-text-secondary truncate">{location}</span>
-          </div>
-          {rating && (
-            <div className="flex items-center gap-1">
-              <Icon path={ICON_PATHS.star} size="sm" className="text-warning" />
-              <span className="text-sm font-semibold text-text-primary">{rating.toFixed(1)}</span>
-              <span className="text-xs text-text-secondary">({service.totalOrders} orders)</span>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Service Title */}
-      <div className="mb-4">
-        <h4 className="font-bold text-text-primary text-base line-clamp-2 leading-tight mb-2">
-          {highlightQuery ? (
-            <HighlightedText text={service.title} query={highlightQuery} />
-          ) : (
-            service.title
-          )}
-        </h4>
-        <p className="text-sm text-text-secondary line-clamp-2 leading-relaxed">
-          {highlightQuery ? (
-            <HighlightedText text={service.description} query={highlightQuery} />
-          ) : (
-            service.description
-          )}
-        </p>
-      </div>
-
-      {/* Category Badge */}
-      <div className="flex items-center gap-2 mb-6">
-        <span className={cn(
-          "px-3 py-1.5 rounded-xl text-xs font-semibold",
-          "bg-background text-text-secondary",
-          "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
-        )}>
-          {category}
-        </span>
-        {service.totalOrders > 10 && (
-          <span className={cn(
-            "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold",
-            "bg-success/10 text-success border border-success/20"
-          )}>
-            <Icon path={ICON_PATHS.check} size="sm" className="text-success" />
-            Top Rated
-          </span>
-        )}
-      </div>
-
-      {/* Stats Section */}
-      <div className="flex items-center justify-between mb-5 pt-4 border-t border-border-light">
-        <div className="flex items-center gap-2">
-          <div className={cn(
-            "w-8 h-8 rounded-lg flex items-center justify-center",
-            "bg-background shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
-          )}>
-            <Icon path={ICON_PATHS.briefcase} size="sm" className="text-text-secondary" />
-          </div>
-          <span className="text-sm font-semibold text-text-primary">{service.totalOrders} orders</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className={cn(
-            "w-8 h-8 rounded-lg flex items-center justify-center",
-            "bg-background shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
-          )}>
-            <Icon path={ICON_PATHS.clock} size="sm" className="text-text-secondary" />
-          </div>
-          <span className="text-sm font-semibold text-text-primary">{service.deliveryDays} days</span>
-        </div>
-      </div>
-
-      {/* Price & CTA */}
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex flex-col">
-          <span className="text-xs text-text-secondary">Starting at</span>
-          <span className="text-2xl font-bold text-primary">${price.toLocaleString()}</span>
-        </div>
-        <button
+      {/* Gradient Image Area */}
+      <div className="relative w-full h-44 overflow-hidden flex-shrink-0">
+        <div
           className={cn(
-            "flex-1 py-3 rounded-xl font-semibold text-sm transition-all duration-200",
-            "bg-primary text-white",
-            "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-            "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
-            "active:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.1)]",
-            "group-hover:bg-primary-hover"
+            "w-full h-full bg-gradient-to-br animate-shimmer flex items-center justify-center",
+            CATEGORY_GRADIENTS[service.category] || CATEGORY_GRADIENTS.OTHER
           )}
         >
-          View Service
-        </button>
+          <Icon
+            path={ICON_PATHS.image}
+            size="lg"
+            className="text-white opacity-40"
+          />
+        </div>
+
+        {/* Badges Overlay */}
+        <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between pointer-events-none">
+          <span className="px-2.5 py-1 rounded-xl text-xs font-semibold bg-black/45 text-white backdrop-blur-md shadow-sm">
+            {category}
+          </span>
+          {service.totalOrders > 10 && (
+            <span className="flex items-center gap-1 px-2.5 py-1 rounded-xl text-xs font-semibold bg-success/85 text-white backdrop-blur-md shadow-sm">
+              <Icon path={ICON_PATHS.check} size="sm" className="text-white" strokeWidth={3} />
+              Top Rated
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-4 flex flex-col flex-grow">
+        {/* Freelancer Header */}
+        <div className="flex items-center gap-3 mb-3">
+          <div className="relative shrink-0">
+            <div className={cn(
+              "w-10 h-10 rounded-xl overflow-hidden transition-all duration-300",
+              "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+              "group-hover:shadow-[inset_1px_1px_2px_#d1d5db,inset_-1px_-1px_2px_#ffffff]"
+            )}>
+              {service.user?.avatarUrl ? (
+                <img
+                  src={service.user.avatarUrl}
+                  alt={displayName}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full bg-background shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff] text-primary flex items-center justify-center font-bold text-base">
+                  {initials.toUpperCase()}
+                </div>
+              )}
+            </div>
+            {service.status === "ACTIVE" && (
+              <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-success rounded-full border border-background shadow-sm" />
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className="font-bold text-text-primary text-sm truncate group-hover:text-primary transition-colors">
+                {displayName}
+              </h3>
+              <div className={cn(
+                "flex-shrink-0 w-4 h-4 rounded-full flex items-center justify-center",
+                "bg-success"
+              )}>
+                <Icon path={ICON_PATHS.check} size="sm" className="text-white" strokeWidth={3} />
+              </div>
+            </div>
+            <div className="flex items-center gap-1">
+              <Icon path={ICON_PATHS.mapPin} size="sm" className="text-text-secondary flex-shrink-0" />
+              <span className="text-xs text-text-secondary truncate">{location}</span>
+              {rating && (
+                <span className="flex items-center gap-0.5 ml-auto text-xs font-semibold text-text-primary">
+                  <Icon path={ICON_PATHS.star} size="sm" className="text-warning" />
+                  {rating.toFixed(1)}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Service Title & Description */}
+        <div className="mb-4">
+          <h4 className="font-bold text-text-primary text-base line-clamp-2 leading-tight mb-2">
+            {highlightQuery ? (
+              <HighlightedText text={service.title} query={highlightQuery} />
+            ) : (
+              service.title
+            )}
+          </h4>
+          <p className="text-sm text-text-secondary line-clamp-2 leading-relaxed">
+            {highlightQuery ? (
+              <HighlightedText text={service.description} query={highlightQuery} />
+            ) : (
+              service.description
+            )}
+          </p>
+        </div>
+
+        {/* Footer (always at bottom) */}
+        <div className="mt-auto">
+          {/* Stats Section */}
+          <div className="flex items-center justify-between mb-4 pt-3 border-t border-border-light">
+            <div className="flex items-center gap-2">
+              <div className={cn(
+                "w-7 h-7 rounded-lg flex items-center justify-center",
+                "bg-background shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+              )}>
+                <Icon path={ICON_PATHS.briefcase} size="sm" className="text-text-secondary" />
+              </div>
+              <span className="text-xs font-semibold text-text-primary">{service.totalOrders} orders</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className={cn(
+                "w-7 h-7 rounded-lg flex items-center justify-center",
+                "bg-background shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+              )}>
+                <Icon path={ICON_PATHS.clock} size="sm" className="text-text-secondary" />
+              </div>
+              <span className="text-xs font-semibold text-text-primary">{service.deliveryDays} days</span>
+            </div>
+          </div>
+
+          {/* Price & CTA */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-col">
+              <span className="text-[10px] text-text-secondary">Starting at</span>
+              <span className="text-xl font-bold text-primary">${price.toLocaleString()}</span>
+            </div>
+            <button
+              className={cn(
+                "flex-1 py-2.5 rounded-xl font-semibold text-sm transition-all duration-200",
+                "bg-primary text-white",
+                "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+                "active:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.1)]",
+                "group-hover:bg-primary-hover"
+              )}
+            >
+              View Service
+            </button>
+          </div>
+        </div>
       </div>
     </Link>
   );


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
fix: uniform card layout with animated gradient placeholder for missing images

## 🛠️ Issue
- No linked issue (production visual fix + Cloudinary migration followup)

## 📚 Description
All marketplace cards now have identical height and layout. Images that were lost during the Railway filesystem wipe no longer show browser broken-image icons — instead, a subtle animated gradient placeholder fills the image area, color-coded by category. Cards with real Cloudinary images continue to show them normally.

## ✅ Changes applied
- `OfferCard.tsx`: fixed `h-44` image area always rendered (not conditional); gradient placeholder per category when no valid `https://` URL; `flex-col h-full` so grid stretches all cards to same height; description `line-clamp-2`; footer pinned with `mt-auto`; removed `BACKEND_URL` prepend (was generating broken local paths)
- `ServiceCard.tsx`: added `h-44` gradient header (services have no image field); category badge + Top Rated badge overlaid on gradient with `backdrop-blur`; freelancer avatar compacted to `w-10 h-10`; footer `mt-auto`; removed unused `Image` import
- `globals.css`: `@keyframes shimmer` shifts `background-position` 0%→100% in 4s — pure CSS, zero JS, negligible CPU

## 🔍 Evidence/Media
- TypeScript: no errors
- DB cleanup: 16 broken offer attachments, 2 portfolio images, 31 avatar URLs already cleaned from production DB