### PR TITLE
feat(chat): implement Chat Message Thread UI (#136)

### DIFF
--- a/src/app/app/chat/[id]/page.tsx
+++ b/src/app/app/chat/[id]/page.tsx
@@ -9,9 +9,8 @@ import { ChatInfoPanel } from "@/components/chat/ChatInfoPanel";
 import { ConnectionStatus } from "@/components/chat/ConnectionStatus";
 import { ConversationList } from "@/components/chat/ConversationList";
 import { MOCK_SHARED_FILES } from "@/data/chat.data";
-import { MessageBubble } from "@/components/chat/MessageBubble";
 import { MessageInput } from "@/components/chat/MessageInput";
-import { TypingIndicator } from "@/components/chat/TypingIndicator";
+import { MessageThread } from "@/components/chat/MessageThread";
 import { cn } from "@/lib/cn";
 import { sendTypingStatus } from "@/lib/api/chat";
 import { useAuthStore } from "@/stores/auth-store";
@@ -29,7 +28,6 @@ export default function ChatThreadPage(): React.JSX.Element {
   const [showConversations, setShowConversations] = useState(false);
   const [showInfo, setShowInfo] = useState(true);
   const [conversationsCollapsed, setConversationsCollapsed] = useState(true);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const chatId = params.id as string;
 
@@ -69,11 +67,6 @@ export default function ChatThreadPage(): React.JSX.Element {
     }
   }, [chatId, fetchMessages]);
 
-  // ── Auto-scroll on new messages ──────────────────────────────────────────
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
   // ── Handlers ─────────────────────────────────────────────────────────────
   function handleToggleConversations(): void {
     setConversationsCollapsed((prev) => !prev);
@@ -83,17 +76,16 @@ export default function ChatThreadPage(): React.JSX.Element {
     await sendMessage(chatId, content);
   }
 
+  async function handleRetryMessage(tempId: string, content: string): Promise<void> {
+    await sendMessage(chatId, content, tempId);
+  }
+
   const handleTypingChange = useCallback(
     (isTyping: boolean) => {
       sendTypingStatus(chatId, isTyping);
     },
     [chatId]
   );
-
-  function shouldShowAvatar(index: number): boolean {
-    if (index === messages.length - 1) return true;
-    return messages[index].senderId !== messages[index + 1].senderId;
-  }
 
   // ── Loading state (initial fetch) ────────────────────────────────────────
   if (isLoadingMessages && messages.length === 0) {
@@ -201,52 +193,19 @@ export default function ChatThreadPage(): React.JSX.Element {
           <ConnectionStatus status={connectionStatus} className="mr-4 shrink-0" />
         </div>
 
-        {/* Load older messages */}
-        {hasMoreMessages && (
-          <div className="flex justify-center py-2 border-b border-border-light">
-            <button
-              type="button"
-              onClick={() => fetchMoreMessages(chatId)}
-              disabled={isLoadingMessages}
-              className={cn(
-                "px-4 py-1.5 rounded-lg text-xs font-medium cursor-pointer",
-                "text-primary bg-background",
-                "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
-                "hover:shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
-                "transition-all duration-200",
-                isLoadingMessages && "opacity-50 cursor-not-allowed"
-              )}
-            >
-              {isLoadingMessages ? "Loading…" : "Load older messages"}
-            </button>
-          </div>
-        )}
-
-        {/* Message list */}
-        <div className={cn("flex-1 overflow-y-auto p-4 sm:p-6 min-h-0", "bg-background")}>
-          <div className="flex items-center justify-center mb-6">
-            <span className="px-3 py-1 text-xs text-text-secondary bg-white rounded-full shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]">
-              Today
-            </span>
-          </div>
-
-          <div className="space-y-4">
-            {messages.map((message, index) => (
-              <div key={message.id} ref={getMessageRef(message)}>
-                <MessageBubble
-                  message={message}
-                  isOwn={message.senderId === currentUserId}
-                  showAvatar={shouldShowAvatar(index)}
-                  participantAvatar={participant?.avatar ?? "?"}
-                />
-              </div>
-            ))}
-
-            {isParticipantTyping && participant && <TypingIndicator name={participant.name} />}
-
-            <div ref={messagesEndRef} />
-          </div>
-        </div>
+        {/* Message history thread */}
+        <MessageThread
+          chatId={chatId}
+          messages={messages}
+          currentUserId={currentUserId}
+          participant={participant}
+          isLoading={isLoadingMessages}
+          hasMore={hasMoreMessages}
+          isTyping={isParticipantTyping}
+          onFetchMore={() => fetchMoreMessages(chatId)}
+          onRetryMessage={handleRetryMessage}
+          getMessageRef={getMessageRef}
+        />
 
         <MessageInput onSendMessage={handleSendMessage} onTypingChange={handleTypingChange} />
       </div>

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -9,9 +9,19 @@ interface MessageBubbleProps {
   isOwn: boolean;
   showAvatar?: boolean;
   participantAvatar?: string;
+  onRetry?: (messageId: string, content: string) => void;
 }
 
-export function MessageBubble({ message, isOwn, showAvatar = true, participantAvatar }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  isOwn,
+  showAvatar = true,
+  participantAvatar,
+  onRetry,
+}: MessageBubbleProps) {
+  const isSending = message.status === "sending";
+  const isError = message.status === "error";
+
   return (
     <div
       className={cn(
@@ -44,10 +54,14 @@ export function MessageBubble({ message, isOwn, showAvatar = true, participantAv
       >
         <div
           className={cn(
-            "px-4 py-3 rounded-2xl",
+            "px-4 py-3 rounded-2xl relative",
             isOwn
               ? cn(
-                  "bg-primary text-white",
+                  isSending
+                    ? "bg-primary/75 text-white/90 animate-pulse-soft"
+                    : isError
+                    ? "bg-error/10 border border-error/20 text-error"
+                    : "bg-primary text-white",
                   "rounded-br-md",
                   "shadow-[4px_4px_8px_#d1d5db,-2px_-2px_4px_#ffffff]"
                 )
@@ -61,6 +75,14 @@ export function MessageBubble({ message, isOwn, showAvatar = true, participantAv
           <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">
             {message.content}
           </p>
+
+          {isOwn && isSending && (
+            <div className="absolute right-2 bottom-1 flex items-center gap-0.5 opacity-80 scale-75 origin-bottom-right">
+              <span className="w-1.5 h-1.5 rounded-full bg-white animate-bounce" style={{ animationDelay: "-0.3s" }}></span>
+              <span className="w-1.5 h-1.5 rounded-full bg-white animate-bounce" style={{ animationDelay: "-0.15s" }}></span>
+              <span className="w-1.5 h-1.5 rounded-full bg-white animate-bounce"></span>
+            </div>
+          )}
         </div>
         <div
           className={cn(
@@ -68,8 +90,25 @@ export function MessageBubble({ message, isOwn, showAvatar = true, participantAv
             isOwn ? "justify-end" : "justify-start"
           )}
         >
-          <span className="text-[10px] text-text-secondary">{message.timestamp}</span>
-          {isOwn && <ReadReceipt message={message} />}
+          {isError ? (
+            <div className="flex items-center gap-2 text-error text-[10px] font-semibold">
+              <span>Failed to send</span>
+              {onRetry && (
+                <button
+                  type="button"
+                  onClick={() => onRetry(message.id, message.content)}
+                  className="underline cursor-pointer hover:text-error-hover transition-colors"
+                >
+                  Retry
+                </button>
+              )}
+            </div>
+          ) : (
+            <>
+              <span className="text-[10px] text-text-secondary">{message.timestamp}</span>
+              {isOwn && !isSending && <ReadReceipt message={message} />}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, type FormEvent } from "react";
+import { useState, useRef, useCallback, useEffect, type FormEvent } from "react";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 
@@ -18,8 +18,28 @@ export function MessageInput({
   disabled = false,
 }: MessageInputProps) {
   const [message, setMessage] = useState("");
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const isTypingRef = useRef(false);
   const typingStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const emojiPickerRef = useRef<HTMLDivElement>(null);
+
+  const POPULAR_EMOJIS = [
+    "😀", "😂", "😍", "👍", "🎉", "🔥", "❤️", "🚀",
+    "🤔", "👏", "🙌", "✨", "💯", "😎", "💡", "😢"
+  ];
+
+  // Close picker on clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (emojiPickerRef.current && !emojiPickerRef.current.contains(event.target as Node)) {
+        setShowEmojiPicker(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   const notifyTypingStop = useCallback(() => {
     if (isTypingRef.current) {
@@ -50,6 +70,11 @@ export function MessageInput({
     [onTypingChange, notifyTypingStop]
   );
 
+  const handleAddEmoji = (emoji: string) => {
+    const newVal = message + emoji;
+    handleChange(newVal);
+  };
+
   function handleSubmit(e: FormEvent<HTMLFormElement>): void {
     e.preventDefault();
     const trimmedMessage = message.trim();
@@ -62,6 +87,7 @@ export function MessageInput({
     notifyTypingStop();
     onSendMessage(trimmedMessage);
     setMessage("");
+    setShowEmojiPicker(false);
   }
 
   return (
@@ -73,14 +99,52 @@ export function MessageInput({
         "bg-white"
       )}
     >
-      {/* Message input */}
+      {/* Message input container */}
       <div
         className={cn(
-          "flex-1 flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl",
+          "flex-1 flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 sm:py-3 rounded-xl relative",
           "bg-background",
           "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
         )}
       >
+        {/* Emoji Selector button */}
+        <div ref={emojiPickerRef} className="relative flex items-center">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setShowEmojiPicker((prev) => !prev)}
+            className={cn(
+              "text-text-secondary hover:text-primary transition-colors p-1 rounded-lg cursor-pointer",
+              showEmojiPicker && "text-primary",
+              disabled && "cursor-not-allowed opacity-50"
+            )}
+            title="Add emoji"
+          >
+            <Icon path={ICON_PATHS.emoji} size="md" />
+          </button>
+
+          {/* Emoji Picker Popup */}
+          {showEmojiPicker && (
+            <div
+              className={cn(
+                "absolute bottom-full left-0 mb-3 p-3 rounded-2xl bg-white border border-border-light z-50 flex flex-wrap gap-2 w-64",
+                "shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff]"
+              )}
+            >
+              {POPULAR_EMOJIS.map((emoji) => (
+                <button
+                  key={emoji}
+                  type="button"
+                  onClick={() => handleAddEmoji(emoji)}
+                  className="text-xl p-1.5 hover:bg-background rounded-lg cursor-pointer transition-all hover:scale-110 active:scale-95"
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
         <input
           type="text"
           value={message}

--- a/src/components/chat/MessageThread.tsx
+++ b/src/components/chat/MessageThread.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/cn";
+import { MessageBubble } from "@/components/chat/MessageBubble";
+import { TypingIndicator } from "@/components/chat/TypingIndicator";
+import { ICON_PATHS, Icon } from "@/components/ui/Icon";
+import type { ChatMessage, ChatUser } from "@/types/chat.types";
+
+interface MessageThreadProps {
+  chatId: string;
+  messages: ChatMessage[];
+  currentUserId?: string;
+  participant?: ChatUser;
+  isLoading: boolean;
+  hasMore: boolean;
+  isTyping: boolean;
+  onFetchMore: () => void;
+  onRetryMessage: (tempId: string, content: string) => void;
+  getMessageRef?: (message: ChatMessage) => (node: HTMLDivElement | null) => void;
+}
+
+/**
+ * Parses and groups simple formatted mock timestamps into dates
+ */
+function getMessageDateGroup(timestamp: string): string {
+  if (!timestamp) return "Today";
+  if (timestamp.includes("Yesterday")) {
+    return "Yesterday";
+  }
+  if (timestamp.includes("Today")) {
+    return "Today";
+  }
+  if (timestamp.includes(",")) {
+    return timestamp.split(",")[0].trim();
+  }
+  // If it's a simple time like "10:15 AM"
+  if (timestamp.match(/^\d{1,2}:\d{2}\s*(AM|PM)$/i)) {
+    return "Today";
+  }
+  return timestamp;
+}
+
+export function MessageThread({
+  chatId,
+  messages,
+  currentUserId,
+  participant,
+  isLoading,
+  hasMore,
+  isTyping,
+  onFetchMore,
+  onRetryMessage,
+  getMessageRef,
+}: MessageThreadProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const savedScrollHeightRef = useRef<number>(0);
+  const lastMessageCountRef = useRef<number>(0);
+
+  // ── Auto-scroll to bottom on new messages ──────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const isNearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 250;
+
+    const isInitialLoad = lastMessageCountRef.current === 0 && messages.length > 0;
+    const isNewMessageSent = messages.length > lastMessageCountRef.current && 
+      messages[messages.length - 1]?.senderId === currentUserId;
+
+    if (isInitialLoad || isNewMessageSent || isNearBottom) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+
+    lastMessageCountRef.current = messages.length;
+  }, [messages, currentUserId]);
+
+  // ── Adjust scroll top to preserve viewport position when loading old messages ────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container && savedScrollHeightRef.current > 0) {
+      const addedHeight = container.scrollHeight - savedScrollHeightRef.current;
+      container.scrollTop = addedHeight;
+      savedScrollHeightRef.current = 0;
+    }
+  }, [messages]);
+
+  // ── Infinite scroll trigger (detecting scroll to top) ──────────────────────
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const container = e.currentTarget;
+    if (container.scrollTop <= 15 && hasMore && !isLoading) {
+      savedScrollHeightRef.current = container.scrollHeight;
+      onFetchMore();
+    }
+  };
+
+  // Determine whether to display avatar based on sender block grouping
+  function shouldShowAvatar(index: number): boolean {
+    if (index === messages.length - 1) return true;
+    return messages[index].senderId !== messages[index + 1].senderId;
+  }
+
+  // ── Group messages by date ────────────────────────────────────────────────
+  const renderedElements: React.JSX.Element[] = [];
+  let lastDateGroup = "";
+
+  messages.forEach((message, index) => {
+    const dateGroup = getMessageDateGroup(message.timestamp);
+    if (dateGroup !== lastDateGroup) {
+      lastDateGroup = dateGroup;
+      renderedElements.push(
+        <div key={`date-${dateGroup}-${index}`} className="flex items-center justify-center my-6">
+          <span className="px-3 py-1 text-xs text-text-secondary bg-white rounded-full shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff] font-medium">
+            {dateGroup}
+          </span>
+        </div>
+      );
+    }
+
+    renderedElements.push(
+      <div
+        key={message.id}
+        ref={getMessageRef ? getMessageRef(message) : undefined}
+      >
+        <MessageBubble
+          message={message}
+          isOwn={message.senderId === currentUserId}
+          showAvatar={shouldShowAvatar(index)}
+          participantAvatar={participant?.avatar ?? "?"}
+          onRetry={onRetryMessage}
+        />
+      </div>
+    );
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className={cn(
+        "flex-1 overflow-y-auto p-4 sm:p-6 min-h-0 relative",
+        "bg-background"
+      )}
+      style={{ contain: "content" }} // Scroll performance optimization
+    >
+      {/* Loading older spinner */}
+      {hasMore && (
+        <div className="flex justify-center mb-4 transition-all duration-200">
+          <button
+            type="button"
+            disabled={isLoading}
+            onClick={() => onFetchMore()}
+            className={cn(
+              "px-4 py-1.5 rounded-lg text-xs font-semibold cursor-pointer",
+              "text-primary bg-white flex items-center gap-1.5",
+              "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+              "hover:shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+              "transition-all duration-200",
+              isLoading && "opacity-60 cursor-not-allowed"
+            )}
+          >
+            {isLoading ? (
+              <>
+                <span className="w-3.5 h-3.5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+                <span>Loading older messages…</span>
+              </>
+            ) : (
+              <span>Load older messages</span>
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Messages list */}
+      <div className="space-y-4">
+        {renderedElements}
+
+        {isTyping && participant && (
+          <div className="animate-fade-in-up stagger-1">
+            <TypingIndicator name={participant.name} />
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ReadReceipt.tsx
+++ b/src/components/chat/ReadReceipt.tsx
@@ -8,7 +8,9 @@ interface ReadReceiptProps {
 }
 
 function getMessageStatus(message: ChatMessage): "sent" | "delivered" | "read" {
-  if (message.status) return message.status;
+  if (message.status === "delivered" || message.status === "read" || message.status === "sent") {
+    return message.status;
+  }
   return message.isRead ? "read" : "sent";
 }
 

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -5,3 +5,4 @@ export { MessageInput } from "./MessageInput";
 export { ChatInfoPanel } from "./ChatInfoPanel";
 export { TypingIndicator } from "./TypingIndicator";
 export { ConnectionStatus } from "./ConnectionStatus";
+export { MessageThread } from "./MessageThread";

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/api/chat";
 
 import { create } from "zustand";
+import { useAuthStore } from "@/stores/auth-store";
 
 const READ_BATCH_DEBOUNCE_MS = 350;
 
@@ -75,7 +76,7 @@ interface ChatState {
   fetchMoreConversations: () => Promise<void>;
   fetchMessages: (conversationId: string) => Promise<void>;
   fetchMoreMessages: (conversationId: string) => Promise<void>;
-  sendMessage: (conversationId: string, content: string) => Promise<void>;
+  sendMessage: (conversationId: string, content: string, tempId?: string) => Promise<void>;
   markAsRead: (conversationId: string, lastReadMessageId?: string) => Promise<void>;
   queueMarkAsRead: (conversationId: string, lastReadMessageId?: string) => void;
 
@@ -205,11 +206,76 @@ export const useChatStore = create<ChatState>()((set, get) => ({
     }));
   },
 
-  sendMessage: async (conversationId: string, content: string) => {
+  sendMessage: async (conversationId: string, content: string, tempId?: string) => {
+    const currentUserId = useAuthStore.getState().user?.id ?? "me";
+    const messageId = tempId || `temp_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+
+    // Create the temporary message
+    const tempMessage: ChatMessage = {
+      id: messageId,
+      senderId: currentUserId,
+      content,
+      timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      isRead: false,
+      status: "sending",
+    };
+
+    // Append (or update if retrying) the message in the store
+    if (!tempId) {
+      get().appendMessage(conversationId, tempMessage);
+    } else {
+      // Retrying, so set status back to "sending"
+      set((state) => {
+        const existing = state.messagesByConversation[conversationId] ?? [];
+        return {
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [conversationId]: existing.map((m) =>
+              m.id === tempId ? { ...m, status: "sending" } : m
+            ),
+          },
+        };
+      });
+    }
+
     const res = await apiSendMessage(conversationId, content);
+
     if (res.ok && res.data) {
-      get().appendMessage(conversationId, res.data);
+      // Replace the temporary message with the real one
+      set((state) => {
+        const existing = state.messagesByConversation[conversationId] ?? [];
+        const index = existing.findIndex((m) => m.id === messageId);
+        if (index >= 0) {
+          const updated = [...existing];
+          updated[index] = res.data!;
+          return {
+            messagesByConversation: {
+              ...state.messagesByConversation,
+              [conversationId]: updated,
+            },
+          };
+        }
+        return {
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [conversationId]: [...existing, res.data!],
+          },
+        };
+      });
       get().updateConversationLastMessage(conversationId, res.data);
+    } else {
+      // Mark as error
+      set((state) => {
+        const existing = state.messagesByConversation[conversationId] ?? [];
+        return {
+          messagesByConversation: {
+            ...state.messagesByConversation,
+            [conversationId]: existing.map((m) =>
+              m.id === messageId ? { ...m, status: "error" } : m
+            ),
+          },
+        };
+      });
     }
   },
 

--- a/src/types/chat.types.ts
+++ b/src/types/chat.types.ts
@@ -12,7 +12,7 @@ export interface ChatMessage {
   content: string;
   timestamp: string;
   isRead: boolean;
-  status?: "sent" | "delivered" | "read";
+  status?: "sending" | "sent" | "delivered" | "read" | "error";
   deliveredAt?: string;
   readAt?: string;
 }


### PR DESCRIPTION
closes #136 
This PR implements the Chat Message Thread UI according to the acceptance criteria of issue #136.

### Acceptance Criteria Covered:
- Created the reusable `MessageThread` component that manages message history layout.
- Integrated dynamic `MessageBubble` component with visual cues for 'sending', 'sent', 'delivered', 'read', and 'error' statuses.
- Added message retry mechanisms for outgoing failures.
- Added premium curated Emoji Selector popup support with click-outside auto-close in `MessageInput`.
- Grouped chat messages dynamically by date separators.
- Optimized auto-scroll and infinite scroll-up offsets to preserve viewport height on pagination.
- Updated the dynamic chat routing at `/app/chat/[id]` and `/app/messages/[id]` pages.