### PR TITLE
fix(fe): prevent text overflow in offer and order detail pages

### DIFF
--- a/src/app/app/client/offers/[id]/page.tsx
+++ b/src/app/app/client/offers/[id]/page.tsx
@@ -277,7 +277,7 @@ export default function OfferPanelPage(): React.JSX.Element {
         <div className="lg:col-span-2 space-y-6">
           <div className={NEUMORPHIC_CARD}>
             <h2 className="text-lg font-semibold text-text-primary mb-4">Description</h2>
-            <p className="text-text-secondary whitespace-pre-line">{offer.description}</p>
+            <p className="text-text-secondary whitespace-pre-line break-words">{offer.description}</p>
           </div>
 
           {offer.apiAttachments && offer.apiAttachments.length > 0 && (

--- a/src/app/app/orders/[id]/page.tsx
+++ b/src/app/app/orders/[id]/page.tsx
@@ -507,7 +507,7 @@ export default function OrderDetailPage(): React.JSX.Element {
         {/* Description */}
         <div className={NEUMORPHIC_CARD}>
           <h2 className="text-lg font-semibold text-text-primary mb-4">Description</h2>
-          <p className="text-text-secondary">{order.description || "No description provided"}</p>
+          <p className="text-text-secondary break-words">{order.description || "No description provided"}</p>
         </div>
       </div>
 

--- a/src/app/marketplace/offers/[id]/page.tsx
+++ b/src/app/marketplace/offers/[id]/page.tsx
@@ -190,7 +190,7 @@ export default function OfferDetailPage(): React.JSX.Element {
               )}
             >
               <h2 className="text-xl font-bold text-text-primary mb-4">Description</h2>
-              <p className="text-text-secondary whitespace-pre-wrap leading-relaxed">{offer.description}</p>
+              <p className="text-text-secondary whitespace-pre-wrap leading-relaxed break-words">{offer.description}</p>
             </div>
 
             {/* Attachments */}


### PR DESCRIPTION
# Frontend Pull Request Description

This Pull Request fixes layout visual overflow bugs on the client dashboard, marketplace offers, and orders details pages.

## Proposed Changes

### Text Overflow Fixes
* **Overflow Protection**: Added `break-words` utility classes to long-form description containers in:
  - Client dashboard offer details page
  - Marketplace offer details page
  - Order details page
* This prevents long strings or contiguous characters from causing horizontal overflow and breaking the layout structure.

---

## Commits
1. `fix(fe): prevent text overflow in offer and order detail pages`

---

## Verification Done
- Verified layout rendering. The text wraps correctly inside containers without visual regressions.
