### PR TITLE
fix(wallet): remove calls to nonexistent /analytics/* endpoints

### DIFF
--- a/src/lib/api/wallet.ts
+++ b/src/lib/api/wallet.ts
@@ -1,9 +1,4 @@
 import { API_URL } from "@/config/api";
-import {
-  getBalanceHistoryAnalytics,
-  getEarningsAnalytics,
-  getSpendingAnalytics,
-} from "@/lib/api/analytics";
 
 export interface WalletBalance {
   currency: string;
@@ -181,27 +176,6 @@ export async function getWalletDashboard(token: string): Promise<WalletDashboard
       currentMonthSpending: "0.00",
       previousMonthSpending: "0.00",
     };
-  }
-
-  // Enrich with analytics endpoints when available (404 = not yet deployed, skip silently)
-  const [earningsRes, spendingRes, historyRes] = await Promise.allSettled([
-    getEarningsAnalytics(token),
-    getSpendingAnalytics(token),
-    getBalanceHistoryAnalytics(token),
-  ]);
-
-  if (earningsRes.status === "fulfilled") {
-    data.monthly.currentMonthEarnings = earningsRes.value.currentMonth;
-    data.monthly.previousMonthEarnings = earningsRes.value.previousMonth;
-  }
-
-  if (spendingRes.status === "fulfilled") {
-    data.monthly.currentMonthSpending = spendingRes.value.currentMonth;
-    data.monthly.previousMonthSpending = spendingRes.value.previousMonth;
-  }
-
-  if (historyRes.status === "fulfilled" && historyRes.value.length > 0) {
-    data.chart = historyRes.value;
   }
 
   return data;


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
fix(wallet): remove calls to nonexistent /analytics/* endpoints

## 🛠️ Issue
- Fixes 404 errors in browser console on every wallet page load

## 📚 Description
The wallet dashboard was calling three analytics endpoints that don't exist in the API:
- `GET /api/v1/analytics/earnings`
- `GET /api/v1/analytics/spending`
- `GET /api/v1/analytics/balance-history`

These calls produced 404 errors in the browser console on every wallet page load. They were handled silently with `Promise.allSettled` so they didn't break the UI, but they generated unnecessary noise and network requests.

The `GET /wallet/dashboard` endpoint already returns `monthly.currentMonthEarnings`, `monthly.currentMonthSpending`, and previous month values directly, making these analytics calls redundant.

## ✅ Changes applied
- `src/lib/api/wallet.ts` — removed `Promise.allSettled` block calling the three analytics endpoints and their unused imports

## 🔍 Evidence/Media
Before: 3 × 404 errors on every wallet page load in browser console.
After: zero analytics 404 errors.