### PR TITLE
feat(auth): show real name in dashboard and profile dropdown

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -31,7 +31,9 @@ export async function POST (request: NextRequest) {
       user: {
         id: user.id,
         email: user.email,
-        username: user.email.split("@")[0],
+        username: user.username ?? user.email.split("@")[0],
+        firstName: user.firstName ?? null,
+        lastName: user.lastName ?? null,
         type: user.type,
         balance: user.balance,
         wallet: user.wallet,

--- a/src/app/app/client/dashboard/page.tsx
+++ b/src/app/app/client/dashboard/page.tsx
@@ -299,7 +299,7 @@ export default function ClientDashboardPage(): React.JSX.Element {
       <div className="flex items-start justify-between gap-4 animate-fade-in-up">
         <div>
           <h1 className="text-3xl font-extrabold text-text-primary tracking-tight">
-            Welcome back, <span className="text-primary">{user?.username ?? "Client"}</span>!
+            Welcome back, <span className="text-primary">{user ? ((user.firstName && user.lastName) ? `${user.firstName} ${user.lastName}` : (user.firstName || user.username || "Client")) : "Client"}</span>!
           </h1>
           <p className="text-text-secondary mt-2 text-lg">
             Find talented freelancers and manage your projects effectively

--- a/src/components/app-shell/AppHeader.tsx
+++ b/src/components/app-shell/AppHeader.tsx
@@ -207,7 +207,9 @@ export function AppHeader({ onMenuClick }: AppHeaderProps): React.JSX.Element {
               <div className={cn(DROPDOWN_MENU, "-right-1 top-[calc(100%+0.75rem)]")}>
                 <div className="px-5 py-4 mb-2 border-b border-background">
                   <p className="text-sm font-bold text-text-primary truncate">
-                    {user.username}
+                    {(user.firstName && user.lastName)
+                      ? `${user.firstName} ${user.lastName}`
+                      : user.firstName || user.username}
                   </p>
                   <p className="text-xs text-text-secondary truncate mt-0.5">
                     {user.email}

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -16,6 +16,8 @@ export interface User {
   id: string;
   email: string;
   username: string;
+  firstName?: string | null;
+  lastName?: string | null;
   avatarUrl?: string;
   type?: "BUYER" | "SELLER" | "BOTH" | "ADMIN";
   balance?: UserBalance;


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
feat(auth): show real name in dashboard and profile dropdown

## 🛠️ Issue
Depends on API PR #101 (must merge first)

## 📚 Description
The dashboard was showing the email prefix (e.g. `josuemarin2009`) instead of the user's real name because the login route was fabricating the username from `email.split('@')[0]` and `firstName`/`lastName` were never passed to the frontend.

This PR wires up the name fields end-to-end once the API PR is merged.

**Priority order for display name:** `firstName + lastName` → `firstName` → `username`

## ✅ Changes applied
- `src/stores/auth-store.ts` — added `firstName?: string | null`, `lastName?: string | null` to `User` interface
- `src/app/api/auth/login/route.ts` — passes `username`, `firstName`, `lastName` from API response instead of fabricating from email
- `src/app/app/client/dashboard/page.tsx` — "Welcome back" uses real name with fallback chain
- `src/components/app-shell/AppHeader.tsx` — profile dropdown shows full name with same fallback chain

## 🔍 Evidence/Media
Before: "Welcome back, josuemarin2009!"
After: "Welcome back, Josue Marin!" (or username if no name set)