### PR TITLE
fix(applications): correct API endpoint paths for offer applications

### DIFF
--- a/src/lib/api/applications.ts
+++ b/src/lib/api/applications.ts
@@ -11,7 +11,7 @@ export async function applyToOffer(
   offerId: string,
   payload: CreateApplicationPayload
 ): Promise<Application> {
-  const response = await fetch(`${API_BASE_URL}/offers/${offerId}/applications`, {
+  const response = await fetch(`${API_BASE_URL}/applications/offers/${offerId}`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,
@@ -70,7 +70,7 @@ export async function getOfferApplications(
   if (filters?.limit) params.append('limit', filters.limit.toString());
   if (filters?.cursor) params.append('cursor', filters.cursor);
 
-  const response = await fetch(`${API_BASE_URL}/offers/${offerId}/applications?${params}`, {
+  const response = await fetch(`${API_BASE_URL}/applications/offers/${offerId}?${params}`, {
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'application/json',


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
fix(applications): correct API endpoint paths for offer applications

## 🛠️ Issue
- N/A (production bug fix)

## 📚 Description
The frontend was calling `/offers/:offerId/applications` but the API exposes these routes under `/applications/offers/:offerId`. This mismatch caused 404 errors whenever a freelancer tried to apply to an offer or a client tried to fetch applicants for their offer.

## ✅ Changes applied
- `applyToOffer`: `/offers/${offerId}/applications` → `/applications/offers/${offerId}`
- `getOfferApplications`: `/offers/${offerId}/applications` → `/applications/offers/${offerId}`

## 🔍 Evidence/Media
Production error observed:
```
POST /api/v1/offers/ofr_mpve603emos7ukqcelb/applications → 404
Failed to apply to offer: Error: Cannot POST /api/v1/offers/ofr_.../applications
```