### PR TITLE
refactor: clean up attachment handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "country-state-city": "^3.2.1",
         "date-fns": "^4.4.0",
         "framer-motion": "^12.34.5",
-        "lucide-react": "^1.7.0",
         "next": "^16.1.1",
         "next-auth": "^5.0.0-beta.30",
         "react": "^19.2.3",
@@ -118,7 +117,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1882,7 +1880,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1922,7 +1919,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2396,7 +2392,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2736,7 +2731,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3463,7 +3457,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3649,7 +3642,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5467,15 +5459,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5613,7 +5596,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -5997,7 +5979,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6085,7 +6066,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6095,7 +6075,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6916,7 +6895,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7091,7 +7069,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7397,7 +7374,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/marketplace/offers/[id]/page.tsx
+++ b/src/app/marketplace/offers/[id]/page.tsx
@@ -11,7 +11,6 @@ import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Navbar } from "@/components/landing/Navbar";
 import { cn } from "@/lib/cn";
-import { BACKEND_URL } from "@/config/api";
 
 const CATEGORY_MAP: Record<string, string> = {
   WEB_DEVELOPMENT: "Web Development",
@@ -109,7 +108,6 @@ export default function OfferDetailPage(): React.JSX.Element {
     );
   }
 
-  const backendUrl = BACKEND_URL;
   const budget = parseFloat(offer.budget);
   const deadline = new Date(offer.deadline).toLocaleDateString("en-US", {
     month: "long",
@@ -124,6 +122,10 @@ export default function OfferDetailPage(): React.JSX.Element {
   });
   // Extract display name from email
   const userName = offer.user?.email?.split("@")[0] || "Anonymous";
+
+  // Only use absolute Cloudinary URLs — /uploads/... paths are broken (ephemeral Railway disk)
+  const validAttachments =
+    offer.attachments?.filter((att) => att.url.startsWith("https://")) ?? [];
 
   return (
     <>
@@ -194,7 +196,7 @@ export default function OfferDetailPage(): React.JSX.Element {
             </div>
 
             {/* Attachments */}
-            {offer.attachments && offer.attachments.length > 0 && (
+            {validAttachments.length > 0 && (
               <div
                 className={cn(
                   "p-6 rounded-3xl bg-white",
@@ -203,10 +205,8 @@ export default function OfferDetailPage(): React.JSX.Element {
               >
                 <h2 className="text-xl font-bold text-text-primary mb-4">Attachments</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  {offer.attachments.map((attachment) => {
-                    const fileUrl = attachment.url.startsWith("http")
-                      ? attachment.url
-                      : `${backendUrl}${attachment.url}`;
+                  {validAttachments.map((attachment) => {
+                    const fileUrl = attachment.url;
                     const isImage = attachment.mimeType.startsWith("image/");
 
                     return (


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- Fix: Offer detail page imports BACKEND_URL for image resolution

## 🛠️ Issue

- Closes #293

## 📚 Description

Since the Cloudinary migration (PR #97), all file URLs stored in the database are absolute Cloudinary `https://` URLs. The offer detail page (`src/app/marketplace/offers/[id]/page.tsx`) still imported `BACKEND_URL` from `@/config/api` and prepended it to attachment paths to build URLs. This is no longer correct and results in broken images/links.

This PR removes the `BACKEND_URL` dependency from the offer detail page and adopts the same `https://` guard already used in `OfferCard.tsx`, so only valid absolute Cloudinary URLs are used. Legacy `/uploads/...` paths are treated as missing and are no longer rendered as broken links.

## ✅ Changes applied

- Removed the `BACKEND_URL` import from `src/app/marketplace/offers/[id]/page.tsx`.
- Removed the `const backendUrl = BACKEND_URL;` assignment.
- Added a `validAttachments` guard that keeps only attachments whose `url` starts with `https://` (same Cloudinary-only pattern as `OfferCard.tsx`).
- Updated the attachments section to render from `validAttachments` and use `attachment.url` directly — no more `${backendUrl}${attachment.url}` concatenation.
- Broken `/uploads/...` paths are filtered out (no broken `<img>` / link); the section is hidden when no valid attachments exist.
- No regressions to offer title, budget, deadline, or the application flow.