### PR TITLE
refactor: remove mock upload functionality 

### DIFF
--- a/src/lib/api/portfolio-images.ts
+++ b/src/lib/api/portfolio-images.ts
@@ -3,13 +3,6 @@ import { validatePortfolioImageFile } from "@/data/portfolio.data";
 
 const API_BASE_URL = API_URL;
 
-/** Match portfolio mock flag in `portfolio.ts` until backend is wired. */
-const USE_MOCK = false;
-
-function simulateDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 function parseUploadPayload(data: unknown): { url: string } {
   if (data && typeof data === "object" && "data" in data) {
     const inner = (data as { data: unknown }).data;
@@ -24,7 +17,7 @@ function parseUploadPayload(data: unknown): { url: string } {
 }
 
 /**
- * Upload a single portfolio image. Mock mode returns a data URL after simulated progress.
+ * Upload a single portfolio image to the backend, reporting upload progress.
  */
 export async function uploadPortfolioImage(
   token: string | null,
@@ -33,24 +26,6 @@ export async function uploadPortfolioImage(
 ): Promise<{ url: string }> {
   const validationError = validatePortfolioImageFile(file);
   if (validationError) throw new Error(validationError);
-
-  if (USE_MOCK) {
-    for (let step = 0; step <= 10; step++) {
-      await simulateDelay(45);
-      onProgress?.(step * 10);
-    }
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const url = reader.result;
-        if (typeof url === "string") resolve({ url });
-        else reject(new Error("Upload failed — could not read image"));
-      };
-      reader.onerror = () =>
-        reject(new Error("Upload failed — could not read image"));
-      reader.readAsDataURL(file);
-    });
-  }
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -94,17 +69,11 @@ export async function uploadPortfolioImage(
 
 /**
  * Optional: delete an image on the server by URL (e.g. after replacing assets).
- * Mock is a no-op.
  */
 export async function deletePortfolioImage(
   token: string | null,
   imageUrl: string
 ): Promise<void> {
-  if (USE_MOCK) {
-    await simulateDelay(100);
-    return;
-  }
-
   const response = await fetch(`${API_BASE_URL}/portfolio/images`, {
     method: "DELETE",
     headers: {


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- Fix: Remove dead mock code from portfolio image API client

## 🛠️ Issue

- Closes #292 

## 📚 Description

The portfolio API layer carried dead mock code behind a `USE_MOCK = false` flag, left over before the backend was wired. While `src/lib/api/portfolio.ts` had already been cleaned up (PR #232), its sibling `src/lib/api/portfolio-images.ts` still contained the same pattern: a `USE_MOCK` constant, a `simulateDelay` helper used only by the mock, and `if (USE_MOCK) { ... }` branches that never execute.

This dead code increased bundle size, complicated future edits, and signaled to contributors that mocking was still an accepted pattern. This PR removes it so every function calls the real backend endpoint only.

> Note: `src/data/portfolio.data.ts` was **not** deleted because it is still imported by `src/components/portfolio/ImageUploader.tsx` and `src/lib/api/portfolio-images.ts` (`validatePortfolioImageFile`).

## ✅ Changes applied

- Removed the `USE_MOCK` constant from `src/lib/api/portfolio-images.ts`.
- Removed the `simulateDelay` helper (only used by the mock branches).
- Removed the dead `if (USE_MOCK) { ... }` branch from `uploadPortfolioImage`.
- Removed the dead `if (USE_MOCK) { ... }` branch from `deletePortfolioImage`.
- Updated JSDoc/comments that referenced "mock mode" / the portfolio mock flag.
- `uploadPortfolioImage` and `deletePortfolioImage` now call the real backend endpoints only (`POST /portfolio/images/upload`, `DELETE /portfolio/images`).
- Verified with `tsc --noEmit`: no type errors.