### PR TITLE
refactor(freelancer-reviews): remove mock data and related functions …

### DIFF
--- a/src/lib/api/freelancer-public.ts
+++ b/src/lib/api/freelancer-public.ts
@@ -7,8 +7,6 @@ import type {
   PublicReviewSort,
 } from "@/types/public-freelancer.types";
 
-const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_FREELANCER_PUBLIC === "true";
-
 function unwrapData<T>(json: unknown): T | null {
   if (!json || typeof json !== "object") return null;
   if ("data" in json && json.data !== null && json.data !== undefined) {
@@ -17,141 +15,11 @@ function unwrapData<T>(json: unknown): T | null {
   return json as T;
 }
 
-const MOCK_SUMMARY: Record<string, PublicFreelancerSummary> = {
-  mock: {
-    id: "mock",
-    displayName: "Alex Morgan",
-    avatarUrl: null,
-    showcaseServiceId: null,
-    averageRating: 4.7,
-    totalReviews: 24,
-    bio: "Full-stack developer focused on clear communication and fast delivery.",
-    skills: ["React", "Node.js", "TypeScript", "AWS"],
-  },
-};
-
-const MOCK_DIST: RatingStats["ratingDistribution"] = {
-  1: 0,
-  2: 1,
-  3: 2,
-  4: 6,
-  5: 15,
-};
-
-function buildMockStats(): RatingStats {
-  const dist = { ...MOCK_DIST };
-  const total = dist[1] + dist[2] + dist[3] + dist[4] + dist[5];
-  const weighted =
-    1 * dist[1] + 2 * dist[2] + 3 * dist[3] + 4 * dist[4] + 5 * dist[5];
-  const avg = total > 0 ? Math.round((weighted / total) * 10) / 10 : 0;
-  return {
-    averageRating: avg,
-    totalRatings: total,
-    ratingDistribution: dist,
-  };
-}
-
-const MOCK_REVIEWS_BASE: Omit<PublicFreelancerReview, "id">[] = [
-  {
-    rating: 5,
-    comment:
-      "Exceptional work — delivered ahead of schedule and communicated clearly throughout the project.",
-    createdAt: new Date(Date.now() - 86400000 * 2).toISOString(),
-    reviewerName: "Jordan Lee",
-    reviewerAvatarUrl: null,
-    serviceTitle: "API integration",
-    response: {
-      content: "Thank you! Happy to collaborate again anytime.",
-      createdAt: new Date(Date.now() - 86400000).toISOString(),
-    },
-  },
-  {
-    rating: 5,
-    comment: "Would hire again without hesitation.",
-    createdAt: new Date(Date.now() - 86400000 * 14).toISOString(),
-    reviewerName: "Sam Rivera",
-    reviewerAvatarUrl: null,
-    serviceTitle: "Landing page",
-    response: null,
-  },
-  {
-    rating: 4,
-    comment: "Solid delivery. Minor revisions needed but overall very satisfied.",
-    createdAt: new Date(Date.now() - 86400000 * 30).toISOString(),
-    reviewerName: "Casey Kim",
-    reviewerAvatarUrl: null,
-    serviceTitle: "Brand assets",
-    response: null,
-  },
-];
-
-function mockSummaryForId(id: string): PublicFreelancerSummary {
-  const base = MOCK_SUMMARY.mock;
-  return {
-    ...base,
-    id,
-    displayName: id === "mock" ? base.displayName : `Freelancer ${id.slice(0, 8)}`,
-  };
-}
-
-function mockReviewsResult(
-  freelancerId: string,
-  params: {
-    page: number;
-    pageSize: number;
-    sort: PublicReviewSort;
-    stars?: number;
-  }
-): PublicFreelancerReviewsResult {
-  let list = MOCK_REVIEWS_BASE.map((r, i) => ({
-    ...r,
-    id: `mock-review-${freelancerId}-${i}`,
-  }));
-
-  if (params.stars && params.stars >= 1 && params.stars <= 5) {
-    list = list.filter((r) => r.rating === params.stars);
-  }
-
-  const sorted = [...list].sort((a, b) => {
-    switch (params.sort) {
-      case "newest":
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      case "oldest":
-        return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-      case "highest":
-        return b.rating - a.rating;
-      case "lowest":
-        return a.rating - b.rating;
-      default:
-        return 0;
-    }
-  });
-
-  const totalItems = sorted.length;
-  const totalPages = totalItems === 0 ? 0 : Math.max(1, Math.ceil(totalItems / params.pageSize));
-  const page = totalPages === 0 ? 1 : Math.min(params.page, totalPages);
-  const start = (page - 1) * params.pageSize;
-  const reviews = sorted.slice(start, start + params.pageSize);
-
-  return {
-    stats: buildMockStats(),
-    reviews,
-    page,
-    pageSize: params.pageSize,
-    totalItems,
-    totalPages,
-  };
-}
-
 /**
  * Public freelancer profile summary (no auth).
  * GET /marketplace/freelancers/:id
  */
 export async function getPublicFreelancerSummary(freelancerId: string): Promise<PublicFreelancerSummary | null> {
-  if (USE_MOCK) {
-    return mockSummaryForId(freelancerId);
-  }
-
   try {
     const response = await fetch(`${API_URL}/marketplace/freelancers/${freelancerId}`, {
       next: { revalidate: 60 },
@@ -203,10 +71,6 @@ export async function getPublicFreelancerReviews(
   const pageSize = Math.min(50, Math.max(5, params.pageSize ?? 10));
   const sort = params.sort ?? "newest";
   const stars = params.stars;
-
-  if (USE_MOCK) {
-    return mockReviewsResult(freelancerId, { page, pageSize, sort, stars });
-  }
 
   const query = new URLSearchParams();
   query.set("page", String(page));


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- fix: remove hardcoded mock review data from `lib/api/freelancer-public.ts`

## 🛠️ Issue

- Closes #285 

## 📚 Description

`src/lib/api/freelancer-public.ts` contained hardcoded fake data: fabricated reviewers
(Jordan Lee, Sam Rivera, Casey Kim) with static ratings/dates in `MOCK_REVIEWS_BASE`, and
a fake profile summary ("Alex Morgan", 4.7 rating) in `MOCK_SUMMARY`. This scaffolding was
gated behind the `NEXT_PUBLIC_USE_MOCK_FREELANCER_PUBLIC` env flag and risked surfacing
fabricated reviews/profiles on public freelancer pages, which is misleading and breaks
trust.

All mock scaffolding has been removed so both public functions
(`getPublicFreelancerSummary` and `getPublicFreelancerReviews`) call the real backend
endpoints only:

- `GET /marketplace/freelancers/:id`
- `GET /marketplace/freelancers/:id/reviews`

Error handling was already throw-based and is left unchanged: `getPublicFreelancerReviews`
propagates API errors (the consumer page catches them and renders an error state), and a
404 returns an empty result that renders the existing "No reviews yet" empty state. No new
error pattern was introduced and no consumer changes were needed.

## ✅ Changes applied

- Removed `MOCK_REVIEWS_BASE` (fake reviewers/ratings/dates) and all references to it.
- Removed the remaining mock scaffolding in the same file: `USE_MOCK` flag, `MOCK_SUMMARY`,
  `MOCK_DIST`, `buildMockStats()`, `mockSummaryForId()`, `mockReviewsResult()`.
- Removed the two `if (USE_MOCK)` early-return branches in `getPublicFreelancerSummary`
  and `getPublicFreelancerReviews`.
- Kept `unwrapData()` and all real fetch/normalization logic (existing repo convention).
- No hardcoded names, ratings, or dates remain in the file.
- No consumer edits: the reviews page (`src/app/marketplace/freelancers/[id]/reviews/page.tsx`)
  already renders an empty state ("No reviews yet") and an error state.

### Out of scope / not testable until backend is live

- The live happy path (rendering real reviews) is only fully testable once
  `GET /marketplace/freelancers/:id/reviews` serves live data. Until then the page shows
  the empty or error state, which is the intended behavior.
- No accessibility code was touched (the issue's referenced "#34" dependency is an
  unrelated accessibility task).

## 🔍 Evidence/Media (screenshots/videos)

<img width="1021" height="272" alt="image" src="https://github.com/user-attachments/assets/49b2d9e7-7a8d-43e4-bb8c-9f7a5a2edc03" />

The command searched the src/ folder for the old mock freelancer review identifiers. It returned no matches, which means those mock references are no longer present in the source code. The exit code 1 is expected for grep when nothing is found.
