### PR TITLE
fix: normalize profile completeness api response for ui consumption

### DIFF
--- a/src/components/profile/ProfileCompleteness.tsx
+++ b/src/components/profile/ProfileCompleteness.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
-import { NEUMORPHIC_CARD, NEUMORPHIC_INSET, PRIMARY_BUTTON } from "@/lib/styles";
+import { NEUMORPHIC_CARD, NEUMORPHIC_INSET } from "@/lib/styles";
 import { getProfileCompleteness, type ProfileCompletenessData } from "@/lib/api/profile";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -12,7 +12,6 @@ export function ProfileCompleteness(): React.JSX.Element | null {
   const { token } = useAuthStore();
   const [data, setData] = useState<ProfileCompletenessData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isCollapsed, setIsCollapsed] = useState(false);
   const [animatedPercentage, setAnimatedPercentage] = useState(0);
 
   useEffect(() => {
@@ -24,9 +23,6 @@ export function ProfileCompleteness(): React.JSX.Element | null {
         const result = await getProfileCompleteness(token!);
         if (isMounted) {
           setData(result);
-          if (result.percentage >= 100) {
-            setIsCollapsed(true);
-          }
         }
       } catch (error) {
         console.error("Failed to fetch profile completeness", error);
@@ -121,9 +117,9 @@ export function ProfileCompleteness(): React.JSX.Element | null {
             Complete the following sections to reach 100% and unlock the All-Star badge.
           </p>
           <div className="space-y-3">
-            {(data.missingFields ?? []).slice(0, 3).map((item, index) => (
+            {(data.missingFields ?? []).slice(0, 3).map((item) => (
               <div
-                key={index}
+                key={item.field}
                 className={cn(
                   "flex items-center justify-between p-3 rounded-xl transition-all hover:bg-black/5",
                   NEUMORPHIC_INSET

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -86,6 +86,69 @@ export interface ProfileCompletenessData {
   isComplete: boolean;
 }
 
+interface ProfileCompletenessApiResponse {
+  percentage: number;
+  completed?: string[];
+  missing: string[];
+  suggestions?: string[];
+}
+
+const PROFILE_COMPLETENESS_FIELD_MAP: Record<string, { label: string; href: string }> = {
+  avatar: { label: "Profile Photo", href: "/app/profile" },
+  firstName: { label: "First Name", href: "/app/profile" },
+  lastName: { label: "Last Name", href: "/app/profile" },
+  username: { label: "Username", href: "/app/profile" },
+  bio: { label: "Bio", href: "/app/profile" },
+  contact: { label: "Phone Number", href: "/app/profile" },
+  title: { label: "Professional Title", href: "/app/profile" },
+  location: { label: "Location", href: "/app/profile" },
+};
+
+function toCompletenessPercentage(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.min(100, Math.max(0, value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return Math.min(100, Math.max(0, parsed));
+    }
+  }
+  return 0;
+}
+
+function formatMissingFieldLabel(field: string): string {
+  return field
+    .replace(/([A-Z])/g, " $1")
+    .replace(/[_-]/g, " ")
+    .trim()
+    .replace(/^\w/, (char) => char.toUpperCase());
+}
+
+function mapMissingField(field: string): ProfileCompletenessData["missingFields"][number] {
+  const config = PROFILE_COMPLETENESS_FIELD_MAP[field];
+
+  return {
+    field,
+    label: config?.label ?? formatMissingFieldLabel(field),
+    href: config?.href ?? "/app/profile",
+  };
+}
+
+function normalizeProfileCompleteness(payload: unknown): ProfileCompletenessData {
+  const raw = (payload && typeof payload === "object" ? payload : {}) as Partial<
+    ProfileCompletenessApiResponse
+  >;
+  const percentage = toCompletenessPercentage(raw.percentage);
+  const missing = Array.isArray(raw.missing) ? raw.missing.filter((field) => typeof field === "string") : [];
+
+  return {
+    percentage,
+    missingFields: missing.map(mapMissingField),
+    isComplete: percentage >= 100,
+  };
+}
+
 /**
  * Get the profile completeness status for the authenticated user
  */
@@ -102,5 +165,5 @@ export async function getProfileCompleteness(token: string): Promise<ProfileComp
   }
 
   const data = await response.json();
-  return data.data;
+  return normalizeProfileCompleteness(data.data);
 }


### PR DESCRIPTION
## Issue

Closes #287

## Description

The `GET /users/me/completeness` endpoint returns a raw payload with `missing`, `completed`, and `suggestions`, but the frontend expected `ProfileCompletenessData` with `missingFields` and `isComplete`. Because of that mismatch, `ProfileCompleteness` never rendered missing items and never detected a complete profile.

This PR adds a normalization layer in `getProfileCompleteness` so the API client always returns the shape consumed by the UI components.

## Changes applied

- Added `normalizeProfileCompleteness` in `src/lib/api/profile.ts` to map the raw API response into `ProfileCompletenessData`
- Derived `missingFields` from the `missing` array with human-readable labels and edit links for: `avatar`, `firstName`, `lastName`, `username`, `bio`, `contact`, `title`, and `location`
- Derived `isComplete` from `percentage >= 100`
- Added a safe fallback for unknown field keys
- Updated `ProfileCompleteness` to use stable `item.field` list keys and removed unused state/imports

## Acceptance criteria

- [x] `getProfileCompleteness` transforms the raw API response into `ProfileCompletenessData`
- [x] `missingFields` is derived from `missing` with proper `label` and `href` values
- [x] `isComplete` is derived from `percentage >= 100`
- [x] `ProfileCompleteness` renders missing items with working links
- [x] `percentage === 100` still collapses/hides the widget

## Testing

- `npx eslint src/lib/api/profile.ts src/components/profile/ProfileCompleteness.tsx`
- `npm run build`

## Notes

Missing-field links point to `/app/profile`, where those fields are edited in the current app structure. This keeps the Add + actions functional for users.