### PR TITLE
Feat: Add empty state UI when marketplace search returns zero results (#288)

### DIFF
--- a/src/app/marketplace/offers/page.tsx
+++ b/src/app/marketplace/offers/page.tsx
@@ -169,7 +169,19 @@ export default function BrowseOffersPage(): React.JSX.Element {
             ) : offers.length === 0 ? (
               <EmptyState
                 icon={ICON_PATHS.briefcase}
-                message="No offers found. Try adjusting your filters or search terms"
+                title="No offers found"
+                message="Try adjusting your filters or search terms"
+                variant="card"
+                actionLabel="Clear filters"
+                onAction={() => {
+                  setSearchInput("");
+                  setSearchText("");
+                  setFilters({
+                    category: "",
+                    minBudget: 0,
+                    maxBudget: 10000,
+                  });
+                }}
               />
             ) : (
               <>

--- a/src/app/marketplace/services/page.tsx
+++ b/src/app/marketplace/services/page.tsx
@@ -169,7 +169,19 @@ export default function BrowseServicesPage(): React.JSX.Element {
               ) : services.length === 0 ? (
                 <EmptyState
                   icon={ICON_PATHS.briefcase}
-                  message="No services found. Try adjusting your filters or search terms"
+                  title="No services found"
+                  message="Try adjusting your filters or search terms"
+                  variant="card"
+                  actionLabel="Clear filters"
+                  onAction={() => {
+                    setSearchInput("");
+                    setSearchText("");
+                    setFilters({
+                      category: "",
+                      minBudget: 0,
+                      maxBudget: 10000,
+                    });
+                  }}
                 />
               ) : (
                 <>


### PR DESCRIPTION
Feat: Add empty state UI when marketplace search returns zero results (#288)

# 📝 Pull Request 

## 🔧 Title: 

- Feat: Add empty state UI when marketplace search returns zero results

## 🛠️ Issue

- Closes #288

## 📚 Description

- This PR introduces a neumorphic Empty State UI component for the Marketplace (both Offers and Services pages). It enhances the user experience by providing clear visual feedback when a search or filter combination yields no results.

## ✅ Changes applied

- Replaced the simple empty text with the `EmptyState` component using the `card` variant to align with the neumorphic design system (`#F3F4F6` background, neumorphic shadow).
- Added view-specific titles ("No offers found" and "No services found") along with an instructional description ("Try adjusting your filters or search terms").
- Implemented an interactive "Clear filters" button within the card that automatically resets all active filters and search terms.
- Ensured the empty state logic does not interfere with the loading state (`LoadingSpinner`).

## 🔍 Evidence/Media (screenshots/videos)

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/35f33949-6d1d-4d6a-a8ca-9cba7f570003" />

