### PR TITLE
Feat: Profile Completeness Indicator UI (FE-005)

### DIFF
--- a/src/app/app/profile/page.tsx
+++ b/src/app/app/profile/page.tsx
@@ -15,6 +15,7 @@ import { getProfile, updateProfile, type UpdateProfileData } from "@/lib/api/pro
 import { uploadImage } from "@/lib/api/upload";
 import Link from "next/link";
 import { ConnectedAccounts } from "@/components/profile/ConnectedAccounts";
+import { ProfileCompleteness } from "@/components/profile/ProfileCompleteness";
 
 interface ProfileFormData {
   firstName: string;
@@ -115,6 +116,7 @@ export default function ProfilePage() {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [isHydrated, setIsHydrated] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [completenessKey, setCompletenessKey] = useState(0);
 
   // Wait for Zustand to hydrate from localStorage
   useEffect(() => {
@@ -193,6 +195,7 @@ export default function ProfilePage() {
       });
 
       console.log("Avatar URL saved to profile");
+      setCompletenessKey((k) => k + 1);
     } catch (error) {
       console.error("Failed to upload image:", error);
 
@@ -260,6 +263,7 @@ export default function ProfilePage() {
       }
 
       setShowSuccess(true);
+      setCompletenessKey((k) => k + 1);
       setTimeout(() => setShowSuccess(false), SUCCESS_MESSAGE_DURATION);
     } catch (error) {
       console.error("Failed to update profile:", error);
@@ -296,6 +300,8 @@ export default function ProfilePage() {
           </Link>
         </div>
       </div>
+
+      <ProfileCompleteness refreshKey={completenessKey} />
 
       <div className={NEUMORPHIC_CARD}>
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/profile/ProfileCompleteness.tsx
+++ b/src/components/profile/ProfileCompleteness.tsx
@@ -8,16 +8,23 @@ import { NEUMORPHIC_CARD, NEUMORPHIC_INSET } from "@/lib/styles";
 import { getProfileCompleteness, type ProfileCompletenessData } from "@/lib/api/profile";
 import { useAuthStore } from "@/stores/auth-store";
 
-export function ProfileCompleteness(): React.JSX.Element | null {
-  const { token } = useAuthStore();
+interface ProfileCompletenessProps {
+  refreshKey?: number;
+}
+
+export function ProfileCompleteness({ refreshKey }: ProfileCompletenessProps): React.JSX.Element | null {
+  const { token, user } = useAuthStore();
   const [data, setData] = useState<ProfileCompletenessData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [animatedPercentage, setAnimatedPercentage] = useState(0);
 
+  const isFreelancer = user?.type === "SELLER" || user?.type === "BOTH";
+
   useEffect(() => {
-    if (!token) return;
+    if (!token || !isFreelancer) return;
 
     let isMounted = true;
+    setIsLoading(true);
     async function fetchCompleteness() {
       try {
         const result = await getProfileCompleteness(token!);
@@ -38,7 +45,7 @@ export function ProfileCompleteness(): React.JSX.Element | null {
     return () => {
       isMounted = false;
     };
-  }, [token]);
+  }, [token, isFreelancer, refreshKey]);
 
   useEffect(() => {
     if (data?.percentage !== undefined) {
@@ -49,6 +56,8 @@ export function ProfileCompleteness(): React.JSX.Element | null {
       return () => clearTimeout(timeout);
     }
   }, [data?.percentage]);
+
+  if (!isFreelancer) return null;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: Integrate ProfileCompleteness widget on the profile page for freelancers

## 🛠️ Issue

- Closes #198

## 📚 Description

- The `ProfileCompleteness` component existed but was never rendered on `/app/profile`.
- Freelancers (SELLER / BOTH role) now see the widget above the profile form so they know which fields are missing.
- Buyer-only accounts see nothing — the widget returns `null` when `user.type === "BUYER"`.
- The widget re-fetches from `GET /users/me/completeness` without a page reload whenever the user saves the profile form or uploads a new avatar, fulfilling the real-time update requirement.

## ✅ Changes applied

- `src/components/profile/ProfileCompleteness.tsx`: add `refreshKey` prop; gate rendering on `isFreelancer` (SELLER/BOTH); reset loading state on each refresh trigger
- `src/app/app/profile/page.tsx`: import and render `<ProfileCompleteness refreshKey={completenessKey} />`; increment `completenessKey` after successful profile save and after avatar upload

## 🔍 Evidence/Media (screenshots/videos)

- TypeScript: `tsc --noEmit` passes with zero errors
- No new lint errors introduced in changed files