### PR TITLE
fix: remove NEXT_PUBLIC_USE_MOCK_SESSIONS flag from lib/api/sessions.ts

### DIFF
--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -11,47 +11,7 @@ export interface Session {
   isCurrent: boolean;
 }
 
-const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_SESSIONS === "true";
-
-// Mock Data
-const MOCK_SESSIONS: Session[] = [
-  {
-    id: "session-1",
-    deviceType: "desktop",
-    os: "Windows 11",
-    browser: "Chrome",
-    ip: "192.168.1.100",
-    location: "New York, USA",
-    lastActivity: new Date().toISOString(),
-    isCurrent: true,
-  },
-  {
-    id: "session-2",
-    deviceType: "mobile",
-    os: "iOS 16",
-    browser: "Safari",
-    ip: "10.0.0.5",
-    location: "New York, USA",
-    lastActivity: new Date(Date.now() - 3600000 * 5).toISOString(), // 5 hours ago
-    isCurrent: false,
-  },
-  {
-    id: "session-3",
-    deviceType: "tablet",
-    os: "Android 13",
-    browser: "Chrome",
-    ip: "192.168.1.101",
-    location: "Boston, USA",
-    lastActivity: new Date(Date.now() - 86400000 * 2).toISOString(), // 2 days ago
-    isCurrent: false,
-  },
-];
-
 export async function fetchSessions(token: string): Promise<Session[]> {
-  if (USE_MOCK) {
-    return [...MOCK_SESSIONS];
-  }
-
   const response = await fetch(`${API_URL}/users/me/sessions`, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -68,10 +28,6 @@ export async function fetchSessions(token: string): Promise<Session[]> {
 }
 
 export async function revokeSession(token: string, sessionId: string): Promise<void> {
-  if (USE_MOCK) {
-    return;
-  }
-
   const response = await fetch(`${API_URL}/users/me/sessions/${sessionId}`, {
     method: "DELETE",
     headers: {
@@ -86,10 +42,6 @@ export async function revokeSession(token: string, sessionId: string): Promise<v
 }
 
 export async function revokeOtherSessions(token: string): Promise<void> {
-  if (USE_MOCK) {
-    return;
-  }
-
   const response = await fetch(`${API_URL}/users/me/sessions/others`, {
     method: "DELETE",
     headers: {


### PR DESCRIPTION
## Summary
Removes the mock session layer from `src/lib/api/sessions.ts` so all
three functions always hit the real backend endpoints.

## Changes
- Deleted `const USE_MOCK` and the `NEXT_PUBLIC_USE_MOCK_SESSIONS` env check
- Deleted `MOCK_SESSIONS` hardcoded array (3 fake sessions)
- `fetchSessions` → always calls `GET /users/me/sessions`
- `revokeSession` → always calls `DELETE /users/me/sessions/:id`
- `revokeOtherSessions` → always calls `DELETE /users/me/sessions/others`
- Errors propagate correctly to the UI (unchanged behaviour)
- `NEXT_PUBLIC_USE_MOCK_SESSIONS` was not present in `.env.example` — no change needed there

## Testing
- [ ] `fetchSessions` returns real sessions from the backend
- [ ] `revokeSession` actually revokes the session (verify in backend logs)
- [ ] `revokeOtherSessions` revokes all non-current sessions
- [ ] UI shows an error toast / state when a request fails (not a silent no-op)

Closes #291