### PR TITLE
Fix: delete account calls wrong API endpoint path

### DIFF
--- a/src/lib/api/account.ts
+++ b/src/lib/api/account.ts
@@ -20,7 +20,7 @@ export async function deleteAccount(
   token: string,
   payload: DeleteAccountPayload
 ): Promise<void> {
-  const response = await fetch(`${API_URL}/users/me`, {
+  const response = await fetch(`${API_URL}/users/profile`, {
     method: "DELETE",
     headers: {
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Change DELETE /users/me to DELETE /users/profile to match the actual backend endpoint. The path mismatch was causing 404 responses, making account deletion silently fail (users could still login after attempting deletion).

# 📝 Pull Request 

## 🔧 Title: 

-

## 🛠️ Issue

- Closes #issue-ID

## 📚 Description

-

## ✅ Changes applied

-

## 🔍 Evidence/Media (screenshots/videos)

-

closes #307 