### PR TITLE
#196 Fix: Wallet API client silently falls back to mock data on API error

### DIFF
--- a/src/app/app/wallet/page.tsx
+++ b/src/app/app/wallet/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuthStore } from "@/stores/auth-store";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { getWalletDashboard, type WalletDashboardData } from "@/lib/api/wallet";
 import {
   BalanceCard,
@@ -131,24 +132,12 @@ export default function WalletPage(): React.JSX.Element {
   if (isLoading || !data) {
     if (error) {
       return (
-        <div className="max-w-lg mx-auto text-center py-16 px-4">
-          <Icon path={ICON_PATHS.creditCard} size="xl" className="mx-auto text-text-secondary mb-4" />
-          <h1 className="text-xl font-bold text-text-primary mb-2">Wallet unavailable</h1>
-          <p className="text-text-secondary mb-6">{error}</p>
-          <button
-            type="button"
-            onClick={() => refresh()}
-            disabled={isRefreshing}
-            className={cn(
-              "inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium",
-              "bg-white text-text-primary shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-              "disabled:opacity-60"
-            )}
-          >
-            <Icon path={ICON_PATHS.refresh} size="sm" className={cn(isRefreshing && "animate-spin")} />
-            Retry
-          </button>
-        </div>
+        <ErrorState
+          title="Wallet unavailable"
+          message={error}
+          onRetry={() => refresh()}
+          retryLabel="Retry"
+        />
       );
     }
     return <WalletPageSkeleton />;

--- a/src/app/app/wallet/transactions/page.tsx
+++ b/src/app/app/wallet/transactions/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuthStore } from "@/stores/auth-store";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { getWalletTransactions, type WalletTransactionsData } from "@/lib/api/wallet";
 import {
   TransactionFilters,
@@ -139,24 +140,12 @@ export default function WalletTransactionsPage(): React.JSX.Element {
   if (isLoading || !data) {
     if (error) {
       return (
-        <div className="max-w-lg mx-auto text-center py-16 px-4">
-          <Icon path={ICON_PATHS.document} size="xl" className="mx-auto text-text-secondary mb-4" />
-          <h1 className="text-xl font-bold text-text-primary mb-2">Transaction history unavailable</h1>
-          <p className="text-text-secondary mb-6">{error}</p>
-          <button
-            type="button"
-            onClick={() => refresh()}
-            disabled={isRefreshing}
-            className={cn(
-              "inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-medium",
-              "bg-white text-text-primary shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
-              "disabled:opacity-60"
-            )}
-          >
-            <Icon path={ICON_PATHS.refresh} size="sm" className={cn(isRefreshing && "animate-spin")} />
-            Retry
-          </button>
-        </div>
+        <ErrorState
+          title="Transaction history unavailable"
+          message={error}
+          onRetry={() => refresh()}
+          retryLabel="Retry"
+        />
       );
     }
     return <TransactionHistorySkeleton />;


### PR DESCRIPTION
 📝 Pull Request - https://github.com/OFFER-HUB/OFFER-HUB-Frontend/pull/316

## 🔧 Title: Fix Wallet API Client — Remove Silent Mock Fallback on API Failure

-## 🛠️ Issue - #196 

- Closes #196 

## 📚 Description
 Description
The wallet API client at src/lib/api/wallet.ts attempts to call the real API (/wallet/dashboard) but silently falls back to a hardcoded MOCK_WALLET_DASHBOARD object whenever the request fails. This makes the wallet dashboard always appear to work in development — showing fake balances and transactions — while hiding real connectivity issues.

This silent fallback is dangerous: it prevents developers from catching broken API integrations early and gives users a false sense of a working wallet.

Acceptance Criteria
 Remove the MOCK_WALLET_DASHBOARD fallback from src/lib/api/wallet.ts
 On API failure, propagate the error to the UI with a clear error state (empty state component or toast)
 Wallet dashboard displays real data from GET /wallet/dashboard and GET /wallet/transactions
 Loading, empty, and error states are handled per the UI state standards
 Integration tested end-to-end with the backend Wallet Dashboard endpoint

Context AI
[https://github.com/OFFER-HUB/OFFER-HUB-Frontend/blob/main/docs/mock-data.md](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FOFFER-HUB%2FOFFER-HUB-Frontend%2Fblob%2Fmain%2Fdocs%2Fmock-data.md)
[https://github.com/OFFER-HUB/OFFER-HUB-Frontend/blob/main/docs/api-response-standard.md](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FOFFER-HUB%2FOFFER-HUB-Frontend%2Fblob%2Fmain%2Fdocs%2Fapi-response-standard.md)
[https://github.com/OFFER-HUB/OFFER-HUB-Frontend/blob/main/docs/ui-states.md](https://www.drips.network/external/https%3A%2F%2Fgithub.com%2FOFFER-HUB%2FOFFER-HUB-Frontend%2Fblob%2Fmain%2Fdocs%2Fui-states.md)

📋 Additional Notes
Blocked by the backend Wallet Dashboard endpoint (API issue #38) and Transaction History endpoint (API issue #39). The existing wallet transaction history endpoint GET /users/:userId/wallet/transactions is partially available. Silent fallbacks should never be used in production code — use the UI states pattern documented in docs/ui-states.md instead.
## ✅ Changes applied

Update wallet dashboard page to use ErrorState component for error handling
- Update transactions page to use ErrorState component for error handling
- Follows UI state standards documented in docs/ui-states.md
- Improves consistency across the application
- No mock data fallback found in wallet.ts (already properly handles errors)


closes #196 


-