### PR TITLE
Fix #308: Notification badge shows red indicator when unread count is 0

### DIFF
--- a/src/components/app-shell/AppHeader.tsx
+++ b/src/components/app-shell/AppHeader.tsx
@@ -158,7 +158,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps): React.JSX.Element {
               size="md"
               className="text-text-secondary"
             />
-            {true && (
+            {unreadCount > 0 && (
               <span
                 className={cn(
                   "absolute -top-1 -right-1",


### PR DESCRIPTION
# 📝 Pull Request 

## 🔧 Title: 

Fix #308 — Notification badge shows red indicator when unread count is 0

## 🛠️ Issue

- Closes #308

## 📚 Description

Changed the badge condition in AppHeader.tsx from `{true && (` to `{unreadCount > 0 && (}` so the red indicator only appears when there are actual unread notifications.

## ✅ Changes applied

- `src/components/app-shell/AppHeader.tsx` — Badge now conditionally renders based on `unreadCount > 0`

## 🔍 Evidence/Media (screenshots/videos)

-
