### PR TITLE
feat: wallet connect button in Navbar with address display and disconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@eslint/eslintrc": "^3.3.3",
         "@types/node": "^25.0.3",
         "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.4",
         "@typescript-eslint/eslint-plugin": "^8.52.0",
         "@typescript-eslint/parser": "^8.52.0",
         "eslint": "^9.39.2",
@@ -6839,6 +6840,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/trusted-types": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@eslint/eslintrc": "^3.3.3",
     "@types/node": "^25.0.3",
     "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.4",
     "@typescript-eslint/eslint-plugin": "^8.52.0",
     "@typescript-eslint/parser": "^8.52.0",
     "eslint": "^9.39.2",

--- a/src/components/app-shell/AppHeader.tsx
+++ b/src/components/app-shell/AppHeader.tsx
@@ -9,6 +9,7 @@ import { Icon, ICON_PATHS } from "@/components/ui/Icon";
 import { useAuthStore } from "@/stores/auth-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { NotificationDropdown } from "@/components/notifications";
+import { WalletConnectButton } from "@/components/wallet/WalletConnectButton";
 import {
   ICON_BUTTON,
   USER_AVATAR_BUTTON,
@@ -138,8 +139,13 @@ export function AppHeader({ onMenuClick }: AppHeaderProps): React.JSX.Element {
         ))}
       </nav>
 
-      {/* Right: notifications + avatar */}
+      {/* Right: wallet + notifications + avatar */}
       <div className="flex items-center gap-3 flex-1 justify-end">
+        {/* Wallet connect / connected address. Hidden below `sm` because the
+            logo, menu toggle, bell and avatar already fill a phone-width bar —
+            the landing navbar's mobile menu carries the entry point there. */}
+        <WalletConnectButton className="hidden sm:flex" />
+
         {/* Notification Bell */}
         <div ref={notifRef} className="relative">
           <button

--- a/src/components/app-shell/AppSidebar.tsx
+++ b/src/components/app-shell/AppSidebar.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+// Imported directly rather than through the wallet barrel: that barrel also
+// re-exports BalanceChart, which would pull recharts into the app shell.
+import { WalletConnectButton } from "@/components/wallet/WalletConnectButton";
 import { useModeStore, getNavigationItems, type UserMode } from "@/stores/mode-store";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { useAuthStore } from "@/stores/auth-store";
@@ -290,6 +293,19 @@ export function AppSidebar({ isOpen, onClose }: AppSidebarProps): React.JSX.Elem
           </>
         )}
       </nav>
+
+      {/*
+        Wallet entry point for narrow viewports only.
+
+        AppHeader carries the same control from `sm` up; below that its bar is
+        already full (menu toggle, wordmark, bell, avatar) and a fifth item
+        overflows it. The drawer is the app shell's equivalent of the landing
+        navbar's mobile menu, so the two surfaces stay consistent and exactly
+        one entry point exists at every width.
+      */}
+      <div className="sm:hidden border-t border-gray-100 p-4">
+        <WalletConnectButton variant="inline" />
+      </div>
     </aside>
   );
 }

--- a/src/components/landing/Navbar.tsx
+++ b/src/components/landing/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { Container, Logo } from "@/components/ui";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { WalletConnectButton } from "@/components/wallet/WalletConnectButton";
 import { cn } from "@/lib/cn";
 import { useAuthStore } from "@/stores/auth-store";
 import {
@@ -191,6 +192,8 @@ export function Navbar(): React.JSX.Element {
           </div>
 
           <div className="hidden lg:flex items-center gap-3">
+            <WalletConnectButton />
+
             {mounted ? (
               isAuthenticated && user ? (
                 <div ref={userMenuRef} className="relative">
@@ -252,7 +255,9 @@ export function Navbar(): React.JSX.Element {
         <div
           className={cn(
             "lg:hidden overflow-hidden transition-all duration-300",
-            isMobileMenuOpen ? "max-h-[600px] pb-4" : "max-h-0"
+            // Raised from 600px: the wallet section adds a full address block and
+            // a disconnect button, which the old ceiling clipped when connected.
+            isMobileMenuOpen ? "max-h-[800px] pb-4" : "max-h-0"
           )}
         >
           <div className="flex flex-col gap-4">
@@ -304,6 +309,8 @@ export function Navbar(): React.JSX.Element {
                 {link.label}
               </Link>
             ))}
+            <WalletConnectButton variant="inline" className="pt-4 border-t border-border-light" />
+
             <div className="flex flex-col gap-3 pt-4 border-t border-border-light">
               {mounted ? (
                 isAuthenticated && user ? (

--- a/src/components/ui/StellarIcon.tsx
+++ b/src/components/ui/StellarIcon.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/cn";
+
+interface StellarIconProps {
+  className?: string;
+}
+
+/**
+ * Stellar brand mark.
+ *
+ * Kept apart from the shared `Icon` component because that one draws stroked
+ * outline glyphs from `ICON_PATHS`, while this mark is a filled shape.
+ */
+export function StellarIcon({ className }: StellarIconProps): React.JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={cn("w-3 h-3", className)}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12.283 1.999L6.36 4.595a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217l-2.554 1.122zm6.44 2.831l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217zm-14.36 4.3l-.392.786a.477.477 0 00.217.638l8.477 3.718a.477.477 0 00.638-.217l.392-.786a.477.477 0 00-.217-.638L4.999 8.913a.477.477 0 00-.638.217zm14.36.9l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217zm-14.36 4.3l-.392.786a.477.477 0 00.217.638l8.477 3.718a.477.477 0 00.638-.217l.392-.786a.477.477 0 00-.217-.638l-8.477-3.718a.477.477 0 00-.638.217zm14.36.9l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217z" />
+    </svg>
+  );
+}

--- a/src/components/ui/WalletAddress.tsx
+++ b/src/components/ui/WalletAddress.tsx
@@ -2,10 +2,16 @@
 
 import { useState, useCallback } from "react";
 import { cn } from "@/lib/cn";
+import { StellarIcon } from "@/components/ui/StellarIcon";
 
 interface WalletAddressProps {
   address: string;
   className?: string;
+  /**
+   * Render the complete public key instead of the truncated form, for places
+   * that have to show the address in full — such as the navbar wallet menu.
+   */
+  showFull?: boolean;
 }
 
 function truncateAddress(address: string): string {
@@ -16,6 +22,7 @@ function truncateAddress(address: string): string {
 export function WalletAddress({
   address,
   className,
+  showFull = false,
 }: WalletAddressProps): React.JSX.Element {
   const [copied, setCopied] = useState(false);
 
@@ -42,25 +49,24 @@ export function WalletAddress({
     >
       {/* Stellar logo */}
       <div className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
-        <svg
-          viewBox="0 0 24 24"
-          className="w-3 h-3 text-primary"
-          fill="currentColor"
-        >
-          <path d="M12.283 1.999L6.36 4.595a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217l-2.554 1.122zm6.44 2.831l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217zm-14.36 4.3l-.392.786a.477.477 0 00.217.638l8.477 3.718a.477.477 0 00.638-.217l.392-.786a.477.477 0 00-.217-.638L4.999 8.913a.477.477 0 00-.638.217zm14.36.9l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217zm-14.36 4.3l-.392.786a.477.477 0 00.217.638l8.477 3.718a.477.477 0 00.638-.217l.392-.786a.477.477 0 00-.217-.638l-8.477-3.718a.477.477 0 00-.638.217zm14.36.9l-8.477 3.718a.477.477 0 00-.217.638l.392.786a.477.477 0 00.638.217l8.477-3.718a.477.477 0 00.217-.638l-.392-.786a.477.477 0 00-.638-.217z" />
-        </svg>
+        <StellarIcon className="text-primary" />
       </div>
 
       {/* Address */}
-      <span className="font-mono text-sm text-text-primary">
-        {truncateAddress(address)}
+      <span
+        className={cn(
+          "font-mono text-sm text-text-primary",
+          showFull && "min-w-0 break-all"
+        )}
+      >
+        {showFull ? address : truncateAddress(address)}
       </span>
 
       {/* Copy button */}
       <button
         onClick={copyToClipboard}
         className={cn(
-          "p-1.5 rounded-lg",
+          "p-1.5 rounded-lg flex-shrink-0",
           "bg-white",
           "shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
           "hover:shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",

--- a/src/components/wallet/WalletConnectButton.tsx
+++ b/src/components/wallet/WalletConnectButton.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { StellarIcon } from "@/components/ui/StellarIcon";
+import { WalletAddress } from "@/components/ui/WalletAddress";
+import { WalletConnectModal } from "@/components/wallet/WalletConnectModal";
+import { DROPDOWN_MENU, DROPDOWN_ITEM_DANGER } from "@/lib/styles";
+import { useAuthStore } from "@/stores/auth-store";
+
+export interface WalletConnectButtonProps {
+  /**
+   * `dropdown` anchors the wallet menu in a popover and suits the header bars.
+   * `inline` stacks the same actions in normal flow, for the landing navbar's
+   * mobile menu — that container is `overflow-hidden`, so it would clip an
+   * absolutely positioned panel.
+   */
+  variant?: "dropdown" | "inline";
+  className?: string;
+}
+
+const TRIGGER_BASE = cn(
+  "flex items-center gap-2 rounded-xl font-semibold",
+  "bg-white",
+  "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+  "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+  "active:shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+  "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
+  "transition-all duration-200 cursor-pointer"
+);
+
+const STELLAR_BADGE = "w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0";
+
+/** Compact form the trigger shows: first four and last four characters. */
+function truncateToEnds(address: string): string {
+  if (address.length <= 8) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+/**
+ * Wallet entry point for the header bars.
+ *
+ * Disconnected it opens `WalletConnectModal`; connected it shows the truncated
+ * public key and a menu holding the full address, a copy button and disconnect.
+ */
+export function WalletConnectButton({
+  variant = "dropdown",
+  className,
+}: WalletConnectButtonProps): React.JSX.Element | null {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const walletAddress = useAuthStore((state) => state.walletAddress);
+  const walletConnected = useAuthStore((state) => state.walletConnected);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  const disconnectWallet = useAuthStore((state) => state.disconnectWallet);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    function handleClickOutside(event: MouseEvent): void {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        setIsMenuOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isMenuOpen]);
+
+  async function handleDisconnect(): Promise<void> {
+    try {
+      await StellarWalletsKit.disconnect();
+    } catch (error) {
+      // The kit can have nothing left to tear down — an uninstalled extension,
+      // storage cleared by the browser. The store still has to be cleared, so
+      // this is reported rather than rethrown.
+      console.error("Failed to disconnect the wallet from Stellar Wallets Kit:", error);
+    }
+
+    disconnectWallet();
+    setIsMenuOpen(false);
+  }
+
+  function openModal(): void {
+    setIsModalOpen(true);
+  }
+
+  function closeModal(): void {
+    setIsModalOpen(false);
+  }
+
+  // Connecting a wallet links it to an account that is already signed in — the
+  // API side (`POST /wallet/connect`) sits behind the JWT guard — so the entry
+  // point only exists for an authenticated user.
+  //
+  // Auth state is unknown until AuthProvider rehydrates the store (created with
+  // `skipHydration`), so nothing renders before that. No space is reserved: the
+  // signed-out landing page is the common case and a placeholder there would be
+  // a gap that never fills.
+  if (!hasHydrated || !isAuthenticated) {
+    return null;
+  }
+
+  const address = walletConnected ? walletAddress : null;
+
+  if (variant === "inline") {
+    return (
+      <div className={cn("flex flex-col gap-3", className)}>
+        {address === null ? (
+          <button
+            type="button"
+            onClick={openModal}
+            aria-haspopup="dialog"
+            className={cn(TRIGGER_BASE, "w-full justify-center px-5 py-3 text-sm text-primary")}
+          >
+            <span className={STELLAR_BADGE}>
+              <StellarIcon className="text-primary" />
+            </span>
+            Connect Wallet
+          </button>
+        ) : (
+          <>
+            <WalletAddress address={address} showFull className="w-full" />
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              className={cn(TRIGGER_BASE, "w-full justify-center px-5 py-3 text-sm text-error")}
+            >
+              <Icon path={ICON_PATHS.logout} size="sm" />
+              Disconnect
+            </button>
+          </>
+        )}
+
+        <WalletConnectModal isOpen={isModalOpen} onClose={closeModal} />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      {address === null ? (
+        <button
+          type="button"
+          ref={triggerRef}
+          onClick={openModal}
+          aria-haspopup="dialog"
+          aria-label="Connect a Stellar wallet"
+          className={cn(TRIGGER_BASE, "px-3 py-2.5 text-sm text-primary sm:px-4")}
+        >
+          <span className={STELLAR_BADGE}>
+            <StellarIcon className="text-primary" />
+          </span>
+          <span className="hidden sm:inline">Connect Wallet</span>
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            ref={triggerRef}
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            aria-haspopup="dialog"
+            aria-expanded={isMenuOpen}
+            aria-label={`Wallet ${truncateToEnds(address)} connected. Open wallet menu`}
+            className={cn(
+              TRIGGER_BASE,
+              "px-3 py-2.5 text-sm text-text-primary sm:px-4",
+              isMenuOpen && "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+            )}
+          >
+            <span className={STELLAR_BADGE}>
+              <StellarIcon className="text-primary" />
+            </span>
+            <span className="hidden font-mono font-medium sm:inline">
+              {truncateToEnds(address)}
+            </span>
+            <Icon
+              path={ICON_PATHS.chevronDown}
+              size="sm"
+              className={cn(
+                "text-text-secondary transition-transform duration-200",
+                isMenuOpen && "rotate-180"
+              )}
+            />
+          </button>
+
+          {isMenuOpen && (
+            <div
+              role="dialog"
+              aria-label="Connected wallet"
+              className={cn(DROPDOWN_MENU, "w-72 right-0 top-[calc(100%+0.75rem)]")}
+            >
+              <div className="px-4 pb-3 border-b border-background">
+                <p className="text-xs text-text-secondary">Connected address</p>
+                <div className="mt-2">
+                  <WalletAddress address={address} showFull className="w-full" />
+                </div>
+              </div>
+
+              <div className="pt-2">
+                <button type="button" onClick={handleDisconnect} className={DROPDOWN_ITEM_DANGER}>
+                  <div className="flex items-center gap-3">
+                    <Icon path={ICON_PATHS.logout} size="sm" />
+                    <span>Disconnect</span>
+                  </div>
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <WalletConnectModal isOpen={isModalOpen} onClose={closeModal} />
+    </div>
+  );
+}

--- a/src/components/wallet/WalletConnectModal.tsx
+++ b/src/components/wallet/WalletConnectModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import Image from "next/image";
 import { StellarWalletsKit, type ISupportedWallet } from "@creit.tech/stellar-wallets-kit";
 import { cn } from "@/lib/cn";
@@ -100,7 +101,7 @@ export function WalletConnectModal({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
-  if (!isOpen) {
+  if (!isOpen || typeof document === "undefined") {
     return null;
   }
 
@@ -139,7 +140,12 @@ export function WalletConnectModal({
 
   const isConnecting = connectingId !== null;
 
-  return (
+  // Portalled to <body>. The landing Navbar is `backdrop-blur-md`, and an
+  // element with a backdrop-filter becomes the containing block for its
+  // fixed-position descendants — rendered in place from the navbar trigger,
+  // this overlay resolved against the header's 64px box instead of the
+  // viewport and sat clamped to the top of the page.
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <button
         type="button"
@@ -310,6 +316,7 @@ export function WalletConnectModal({
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/wallet/index.ts
+++ b/src/components/wallet/index.ts
@@ -5,6 +5,7 @@ export { TransactionFilters } from "./TransactionFilters";
 export { TransactionHistorySkeleton } from "./TransactionHistorySkeleton";
 export { TransactionItem } from "./TransactionItem";
 export { TransactionList } from "./TransactionList";
+export { WalletConnectButton } from "./WalletConnectButton";
 export { WalletConnectModal } from "./WalletConnectModal";
 export { WalletPageSkeleton } from "./WalletPageSkeleton";
 export { WithdrawModal } from "./WithdrawModal";


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat: wallet connect button in Navbar with address display and disconnect

## 🛠️ Issue

- Closes #322

## 📚 Description

Adds the wallet connection entry point to the Navbar. Disconnected it opens the existing `WalletConnectModal`; connected it shows the truncated address and a menu with the full key, a copy button and disconnect.

Most of the plumbing had already landed (`WalletConnectModal`, `WalletKitProvider`, `use-wallet-kit`, and the `walletConnected` / `connectWallet` / `disconnectWallet` slice of the auth store), so this is the entry point on top of it — the modal is wired, not rebuilt.

### The button only renders for a signed-in user

Connecting a wallet **links it to an existing account** — the API side, `POST /wallet/connect`, sits behind the JWT guard — so the entry point has no meaning while signed out. `WalletConnectButton` reads `isAuthenticated` and renders nothing otherwise.

No space is reserved pre-hydration. Auth state is unknown until `AuthProvider` rehydrates the store (created with `skipHydration`), and the signed-out landing page is the common case, so a placeholder there would be a gap that never fills.

### Modal centering fix

The modal was rendering clamped to the top of the page rather than centered, and the cause was not in the modal. **An element with a `backdrop-filter` becomes the containing block for its `position: fixed` descendants.** The landing `<header>` is `backdrop-blur-md`, so once the modal was opened from a trigger inside it, `fixed inset-0` resolved against the header's 64px box instead of the viewport. The mobile menu would have clipped it as well, being `overflow-hidden`.

Fixed by portalling the overlay to `document.body`, which detaches it from both. This required adding `@types/react-dom` — see below.

### Which navbars

Both, through one extracted component:

- **`landing/Navbar.tsx`** — the primary target. It renders on the public site and every `/marketplace/*` page. Full desktop + mobile support; the mobile menu's `max-h` went from 600px to 800px because the connected state adds a full address block and a disconnect button that the old ceiling clipped.
- **`app-shell/AppHeader.tsx`** — same component so the connected state stays visible inside the app shell, but **hidden below `sm` (640px)**. On a 375px viewport the bar already spends roughly 349px on the menu toggle, wordmark, bell and avatar; a fifth control overflows it.
- **`app-shell/AppSidebar.tsx`** — carries the control **only below `sm`** (`sm:hidden`), covering exactly the range the header gives up. The drawer is the app shell's equivalent of the landing navbar's mobile menu, so the two surfaces behave the same way and **exactly one entry point exists at every width** — no duplication on desktop.

The navbars import `WalletConnectButton` **directly rather than through `components/wallet/index.ts`**, because that barrel also re-exports `BalanceChart` and would pull recharts into the landing bundle.

## ✅ Changes applied

Five atomic commits:

| Commit | Change |
|---|---|
| `chore(deps)` | `@types/react-dom` |
| `fix(wallet)` | `WalletConnectModal` portalled to `document.body` |
| `feat(ui)` | `StellarIcon` extracted; `showFull` mode on `WalletAddress` |
| `feat(wallet)` | `WalletConnectButton` (`dropdown` + `inline` variants) |
| `feat(navbar)` | Wired into `Navbar` and `AppHeader` |
| `feat(navbar)` | Wallet entry added to the mobile sidebar drawer (`sm:hidden`) |

**Dependency note:** `react-dom` is a direct dependency but ships no type definitions, and only its `@types/react` counterpart was installed — a pre-existing gap. Importing `createPortal` therefore resolved to an implicit `any` and failed the strict typecheck, so `@types/react-dom@^19` was added to `devDependencies`. Types-only, for a package already present; no new runtime dependency.

`WalletAddress`'s new `showFull` prop defaults to `false`, leaving both existing call sites unchanged.

**Accessibility:** `aria-expanded` / `aria-haspopup` / `aria-label` on the trigger, `role="dialog"` on the panel (matching `NotificationDropdown`), Escape closes and returns focus to the trigger, mousedown-outside closes, `focus-visible` ring. No focus trap — the popover is a disclosure, not a modal, so trapping would be the wrong pattern.

## 🔍 Evidence/Media (screenshots/videos)

Verified against the full stack running locally — frontend on :3000 against the API on :4000 (`NEXT_PUBLIC_USE_LOCAL_API=true`), with Postgres and Redis up.

```
$ npx tsc --noEmit
exit 0

$ npm run build
✓ Compiled successfully in 3.7s

$ npx eslint .
✖ 91 problems (86 errors, 5 warnings)
```

The 91 lint problems are **byte-identical to the baseline at `main`** — the full per-file problem list was diffed before and after; the only change is two line numbers shifting by one from added imports. Zero new problems. They are all pre-existing (`no-explicit-any` in `lib/api/*`, unused vars in `proxy.ts`).

Both new files are Prettier-clean. The modified files still fail `format:check`, but they already failed at `HEAD` (verified per-file via `git show HEAD:<file> | prettier --check`); 305 files fail repo-wide, so reformatting them here would only add diff noise.

### Two things reviewers should know

1. **There is no test suite in this repo** — no vitest or jest config, no `*.test.*` / `*.spec.*` files, no test script. Nothing was removed; there was never a harness. `npm run build` is the strongest available automated gate, so this change rests on the manual verification above.
2. **Pre-existing sync gap, not introduced here and not fixed here:** the auth store's wallet slice and Stellar Wallets Kit persist to localStorage independently. If one is cleared and the other is not, the navbar (reading the store) and the modal (reading `useWalletKit().address`) can disagree. It self-heals — opening the modal shows the connected view. The reconciliation belongs in `WalletKitProvider`, not in a navbar button, so it is left for its own issue.
