### PR TITLE
feat: XLM + USDC balance display from connected wallet (Horizon)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,17 @@ NEXT_PUBLIC_PRODUCTION_API_URL=https://offer-hub-api-production.up.railway.app/a
 # Stellar network the Stellar Wallets Kit signs against.
 # Accepts "testnet" or "public". Anything else falls back to testnet.
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Horizon REST endpoint used to read XLM / USDC balances.
+# Optional. Leave unset to derive it from NEXT_PUBLIC_STELLAR_NETWORK
+# (testnet -> https://horizon-testnet.stellar.org, public -> https://horizon.stellar.org).
+# Only override for a local or self-hosted Horizon; a value that is not an
+# http(s) URL is ignored and the network default is used.
+# NEXT_PUBLIC_STELLAR_HORIZON_URL=http://localhost:8000
+
+# USDC issuer account used to identify the USDC trustline.
+# Optional. Defaults to Circle's issuer for the active network
+# (testnet -> GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5,
+#  public  -> GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN).
+# A value that is not a Stellar public key is ignored.
+# NEXT_PUBLIC_STELLAR_USDC_ISSUER=

--- a/src/app/app/wallet/page.tsx
+++ b/src/app/app/wallet/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuthStore } from "@/stores/auth-store";
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { useWalletBalance } from "@/hooks/useWalletBalance";
 import { getWalletDashboard, type WalletDashboardData } from "@/lib/api/wallet";
 import {
   BalanceCard,
@@ -41,6 +42,11 @@ export default function WalletPage(): React.JSX.Element {
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const [withdrawSuccess, setWithdrawSuccess] = useState<string | null>(null);
 
+  // On-chain balances of the connected external wallet (SCF D1.1). Independent
+  // of the platform ledger above: it loads on connection and refreshes on its own.
+  const walletBalance = useWalletBalance();
+  const refreshWalletBalance = walletBalance.refresh;
+
   const load = useCallback(async () => {
     if (!token) {
       setData(null);
@@ -67,10 +73,11 @@ export default function WalletPage(): React.JSX.Element {
   }, [load]);
 
   const refresh = useCallback(() => {
+    refreshWalletBalance();
     if (!token) return;
     setIsRefreshing(true);
     void load();
-  }, [token, load]);
+  }, [token, load, refreshWalletBalance]);
 
   const pullStart = useRef(0);
   const pulling = useRef(false);
@@ -234,6 +241,19 @@ export default function WalletPage(): React.JSX.Element {
           available={data.balance.available}
           reserved={data.balance.reserved}
           currency={data.balance.currency}
+          externalWallet={
+            walletBalance.address === null
+              ? undefined
+              : {
+                  address: walletBalance.address,
+                  balances: walletBalance.balances,
+                  isLoading: walletBalance.isLoading,
+                  isRefreshing: walletBalance.isRefreshing,
+                  error: walletBalance.error,
+                  isUnfunded: walletBalance.isUnfunded,
+                  onRefresh: refreshWalletBalance,
+                }
+          }
         />
       </div>
 

--- a/src/components/wallet/BalanceCard.tsx
+++ b/src/components/wallet/BalanceCard.tsx
@@ -2,14 +2,34 @@
 
 import { cn } from "@/lib/cn";
 import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import {
+  WalletAssetBalances,
+  type WalletAssetBalancesProps,
+} from "@/components/wallet/WalletAssetBalances";
+
+/**
+ * Live Horizon balances for a connected external wallet. Everything the
+ * `useWalletBalance` hook returns, plus its refresh callback.
+ */
+export type BalanceCardExternalWallet = Omit<WalletAssetBalancesProps, "className">;
 
 interface BalanceCardProps {
   available: string;
   reserved: string;
   currency: string;
   className?: string;
+  /**
+   * On-chain XLM and USDC of the connected `WalletType.EXTERNAL` wallet.
+   * Omitted for custodial (INVISIBLE) wallets, which hold nothing on Horizon —
+   * the card then renders exactly as before.
+   */
+  externalWallet?: BalanceCardExternalWallet;
 }
 
+/**
+ * Formats the platform ledger balance, which is a fiat currency. Not reusable
+ * for XLM or USDC: `style: "currency"` requires an ISO 4217 code.
+ */
 function formatMoney(value: string, currency: string): string {
   const n = parseFloat(value);
   if (Number.isNaN(n)) return value;
@@ -24,6 +44,7 @@ export function BalanceCard({
   reserved,
   currency,
   className,
+  externalWallet,
 }: BalanceCardProps): React.JSX.Element {
   const availN = parseFloat(available);
   const resN = parseFloat(reserved);
@@ -80,6 +101,13 @@ export function BalanceCard({
           <p className="text-lg font-semibold text-warning">{formatMoney(reserved, currency)}</p>
         </div>
       </div>
+
+      {externalWallet ? (
+        <WalletAssetBalances
+          {...externalWallet}
+          className="mt-6 pt-6 border-t border-border-light"
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/wallet/WalletAssetBalances.tsx
+++ b/src/components/wallet/WalletAssetBalances.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useId } from "react";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { STELLAR_NETWORK } from "@/config/wallet";
+import { buildAccountExplorerUrl } from "@/services/stellar.service";
+import type { StellarAccountBalances, StellarAssetBalance } from "@/types/wallet.types";
+
+export interface WalletAssetBalancesProps {
+  /** Public key of the connected wallet. */
+  address: string;
+  /** Balances read from Horizon, or null while none have loaded yet. */
+  balances: StellarAccountBalances | null;
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error: string | null;
+  /** True when the account has never been funded on this network. */
+  isUnfunded: boolean;
+  onRefresh: () => void;
+  className?: string;
+}
+
+/**
+ * `Intl.NumberFormat` cannot format these with `style: "currency"` — neither XLM
+ * nor USDC is an ISO 4217 code — so amounts are formatted as plain decimals and
+ * the asset code is rendered as the tile label instead. Stellar carries 7
+ * decimal places; trailing zeros past two are dropped, so a whole balance still
+ * reads as "25.00".
+ */
+const AMOUNT_FORMATTER = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 7,
+});
+
+function formatAssetAmount(balance: string): string {
+  const amount = Number.parseFloat(balance);
+  return Number.isFinite(amount) ? AMOUNT_FORMATTER.format(amount) : balance;
+}
+
+function truncateAddress(address: string): string {
+  return `${address.slice(0, 6)}…${address.slice(-6)}`;
+}
+
+const TILE_STYLES = cn(
+  "p-4 rounded-2xl bg-background",
+  "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+);
+
+interface AssetTileProps {
+  asset: StellarAssetBalance;
+  caption: string;
+}
+
+function AssetTile({ asset, caption }: AssetTileProps): React.JSX.Element {
+  return (
+    <div className={TILE_STYLES}>
+      <p className="text-xs font-medium text-text-secondary uppercase tracking-wide mb-1">
+        {asset.code}
+      </p>
+      <p className="text-lg font-semibold text-text-primary tabular-nums break-all">
+        {formatAssetAmount(asset.balance)}
+      </p>
+      <p className="text-xs text-text-secondary mt-1">
+        {asset.hasTrustline ? caption : `No ${asset.code} trustline yet`}
+      </p>
+    </div>
+  );
+}
+
+function BalancesSkeleton(): React.JSX.Element {
+  return (
+    <div role="status" aria-live="polite">
+      <span className="sr-only">Loading on-chain balances</span>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 animate-pulse" aria-hidden="true">
+        <div className={cn(TILE_STYLES, "h-[86px]")} />
+        <div className={cn(TILE_STYLES, "h-[86px]")} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * XLM and USDC held by a connected external (non-custodial) wallet, read live
+ * from Horizon. Rendered inside `BalanceCard` for `WalletType.EXTERNAL` wallets;
+ * custodial balances keep using the platform ledger figures above it.
+ */
+export function WalletAssetBalances({
+  address,
+  balances,
+  isLoading,
+  isRefreshing,
+  error,
+  isUnfunded,
+  onRefresh,
+  className,
+}: WalletAssetBalancesProps): React.JSX.Element {
+  const titleId = useId();
+
+  return (
+    <section
+      className={cn("space-y-3", className)}
+      aria-labelledby={titleId}
+      aria-busy={isLoading || isRefreshing}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h3 id={titleId} className="text-sm font-semibold text-text-primary">
+            Connected wallet
+          </h3>
+          <p className="text-xs text-text-secondary">
+            <span className="font-mono">{truncateAddress(address)}</span>
+            <span className="mx-1.5" aria-hidden="true">
+              ·
+            </span>
+            <span>{STELLAR_NETWORK === "public" ? "Stellar mainnet" : "Stellar testnet"}</span>
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <a
+            href={buildAccountExplorerUrl(address)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium",
+              "text-text-secondary hover:text-primary transition-colors",
+              "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none"
+            )}
+          >
+            <Icon path={ICON_PATHS.externalLink} size="sm" />
+            Explorer
+          </a>
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={isLoading || isRefreshing}
+            aria-label="Refresh on-chain balances"
+            className={cn(
+              "inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-medium",
+              "bg-white text-text-primary",
+              "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+              "hover:shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]",
+              "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
+              "disabled:opacity-60 disabled:cursor-not-allowed",
+              "transition-all duration-200"
+            )}
+          >
+            <Icon
+              path={ICON_PATHS.refresh}
+              size="sm"
+              className={cn(isRefreshing && "animate-spin")}
+            />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {isLoading ? <BalancesSkeleton /> : null}
+
+      {!isLoading && error !== null ? (
+        <div
+          role="alert"
+          className={cn(
+            "flex flex-wrap items-center justify-between gap-3 p-4 rounded-2xl",
+            "bg-error/10 border border-error/20"
+          )}
+        >
+          <p className="flex items-start gap-2 text-sm text-error">
+            <Icon path={ICON_PATHS.alertCircle} size="sm" className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </p>
+          <button
+            type="button"
+            onClick={onRefresh}
+            className={cn(
+              "px-4 py-2 rounded-xl text-xs font-medium bg-white text-text-primary",
+              "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+              "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none"
+            )}
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {!isLoading && error === null && balances !== null ? (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4" aria-live="polite">
+            <AssetTile asset={balances.xlm} caption="Native Stellar balance" />
+            <AssetTile asset={balances.usdc} caption="Stablecoin balance" />
+          </div>
+          {isUnfunded ? (
+            <p role="status" className="flex items-start gap-2 text-xs text-text-secondary">
+              <Icon path={ICON_PATHS.infoCircle} size="sm" className="mt-0.5 shrink-0" />
+              <span>
+                This account is not funded on {STELLAR_NETWORK === "public" ? "mainnet" : "testnet"}{" "}
+                yet. Balances appear once it receives its first payment.
+              </span>
+            </p>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/wallet/index.ts
+++ b/src/components/wallet/index.ts
@@ -5,6 +5,7 @@ export { TransactionFilters } from "./TransactionFilters";
 export { TransactionHistorySkeleton } from "./TransactionHistorySkeleton";
 export { TransactionItem } from "./TransactionItem";
 export { TransactionList } from "./TransactionList";
+export { WalletAssetBalances } from "./WalletAssetBalances";
 export { WalletConnectButton } from "./WalletConnectButton";
 export { WalletConnectModal } from "./WalletConnectModal";
 export { WalletPageSkeleton } from "./WalletPageSkeleton";

--- a/src/config/wallet.ts
+++ b/src/config/wallet.ts
@@ -18,3 +18,77 @@ const CONFIGURED_NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
  */
 export const STELLAR_NETWORK: StellarNetworkName =
   CONFIGURED_NETWORK === "public" ? "public" : "testnet";
+
+const HORIZON_URL_BY_NETWORK: Record<StellarNetworkName, string> = {
+  testnet: "https://horizon-testnet.stellar.org",
+  public: "https://horizon.stellar.org",
+};
+
+const EXPLORER_URL_BY_NETWORK: Record<StellarNetworkName, string> = {
+  testnet: "https://stellar.expert/explorer/testnet",
+  public: "https://stellar.expert/explorer/public",
+};
+
+/**
+ * Circle's USDC issuers. Reading a balance means matching `asset_code` **and**
+ * `asset_issuer`, because anyone can issue an asset called "USDC" — the code
+ * alone is not an identity.
+ */
+const USDC_ISSUER_BY_NETWORK: Record<StellarNetworkName, string> = {
+  testnet: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  public: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+};
+
+/** Stellar public keys are strkey-encoded ed25519 keys: "G" plus 55 base32 chars. */
+const STELLAR_PUBLIC_KEY_PATTERN = /^G[A-Z2-7]{55}$/;
+
+function readHttpUrlOverride(value: string | undefined): string | null {
+  if (value === undefined || value.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return parsed.origin + parsed.pathname.replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function readPublicKeyOverride(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return STELLAR_PUBLIC_KEY_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Horizon REST base URL, without a trailing slash.
+ *
+ * Defaults are derived from {@link STELLAR_NETWORK} so the URL can never
+ * disagree with the network SWK signs against. The override exists for local
+ * Horizon instances and is ignored unless it parses as an http(s) URL.
+ *
+ * Balances are read over plain REST rather than through `@stellar/stellar-sdk`:
+ * the SDK is not a direct dependency here (it only appears as a transitive copy
+ * under the wallet kit), and a thin wrapper is what the T3 Horizon -> Stellar
+ * RPC migration (D3.1) has to swap out anyway.
+ */
+export const HORIZON_URL: string =
+  readHttpUrlOverride(process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL) ??
+  HORIZON_URL_BY_NETWORK[STELLAR_NETWORK];
+
+/** Block explorer base URL for the active network, without a trailing slash. */
+export const STELLAR_EXPLORER_URL: string = EXPLORER_URL_BY_NETWORK[STELLAR_NETWORK];
+
+/** Asset code of the stablecoin shown next to XLM. */
+export const USDC_ASSET_CODE = "USDC";
+
+/**
+ * USDC issuer for the active network. A malformed override falls back to the
+ * network default rather than silently matching nothing.
+ */
+export const USDC_ISSUER: string =
+  readPublicKeyOverride(process.env.NEXT_PUBLIC_STELLAR_USDC_ISSUER) ??
+  USDC_ISSUER_BY_NETWORK[STELLAR_NETWORK];

--- a/src/hooks/useWalletBalance.ts
+++ b/src/hooks/useWalletBalance.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  HorizonRequestError,
+  StellarAccountNotFoundError,
+  emptyAccountBalances,
+  fetchAccountBalances,
+} from "@/services/stellar.service";
+import type { StellarAccountBalances } from "@/types/wallet.types";
+
+const FALLBACK_ERROR_MESSAGE = "Could not load balances from Horizon. Try again.";
+
+/** Result keyed by the address it belongs to, so a wallet switch cannot show stale numbers. */
+interface BalanceSnapshot {
+  address: string;
+  balances: StellarAccountBalances;
+  isUnfunded: boolean;
+}
+
+interface BalanceFailure {
+  address: string;
+  message: string;
+}
+
+export interface UseWalletBalanceResult {
+  /** Address the balances belong to, or null when no wallet is connected. */
+  address: string | null;
+  /** XLM and USDC balances, or null before the first result for `address`. */
+  balances: StellarAccountBalances | null;
+  /** True while the first load for the connected wallet is pending. */
+  isLoading: boolean;
+  /** True while a refresh runs over balances that are already on screen. */
+  isRefreshing: boolean;
+  /** Failure message for the connected wallet, or null. */
+  error: string | null;
+  /**
+   * True when Horizon has no record of the account. `balances` is then a zeroed
+   * record rather than null — an unfunded keypair is a valid state, not an error.
+   */
+  isUnfunded: boolean;
+  /** Re-read balances from Horizon. No-op while no wallet is connected. */
+  refresh: () => void;
+}
+
+function toErrorMessage(cause: unknown): string {
+  if (cause instanceof HorizonRequestError || cause instanceof Error) {
+    return cause.message.length > 0 ? cause.message : FALLBACK_ERROR_MESSAGE;
+  }
+  return FALLBACK_ERROR_MESSAGE;
+}
+
+/**
+ * XLM and USDC balances of the wallet connected in the auth store (SCF D1.1).
+ *
+ * Loads on connection and whenever the connected address changes; `refresh()`
+ * re-reads on demand. Only one request is ever in flight — a new load aborts
+ * the previous one, so a fast reconnect cannot resolve out of order.
+ */
+export function useWalletBalance(): UseWalletBalanceResult {
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  const storedAddress = useAuthStore((state) => state.walletAddress);
+
+  // Before rehydration the store reports no wallet even for a user who has one,
+  // so treat that window as "unknown" instead of "disconnected".
+  const address = hasHydrated ? storedAddress : null;
+
+  const [snapshot, setSnapshot] = useState<BalanceSnapshot | null>(null);
+  const [failure, setFailure] = useState<BalanceFailure | null>(null);
+  const [isRefreshRequested, setIsRefreshRequested] = useState(false);
+  const requestRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async (target: string): Promise<void> => {
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+
+    try {
+      const balances = await fetchAccountBalances(target, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      setSnapshot({ address: target, balances, isUnfunded: false });
+      setFailure(null);
+    } catch (cause) {
+      if (controller.signal.aborted) return;
+
+      if (cause instanceof StellarAccountNotFoundError) {
+        setSnapshot({ address: target, balances: emptyAccountBalances(), isUnfunded: true });
+        setFailure(null);
+        return;
+      }
+
+      setFailure({ address: target, message: toErrorMessage(cause) });
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsRefreshRequested(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (address === null) {
+      requestRef.current?.abort();
+      setIsRefreshRequested(false);
+      return;
+    }
+
+    void load(address);
+
+    return () => requestRef.current?.abort();
+  }, [address, load]);
+
+  const refresh = useCallback(() => {
+    if (address === null) return;
+    setIsRefreshRequested(true);
+    setFailure(null);
+    void load(address);
+  }, [address, load]);
+
+  const isCurrent = snapshot !== null && snapshot.address === address;
+  const balances = isCurrent ? snapshot.balances : null;
+  const isUnfunded = isCurrent ? snapshot.isUnfunded : false;
+  const error = failure !== null && failure.address === address ? failure.message : null;
+
+  return {
+    address,
+    balances,
+    // Derived rather than stored: true from the render the address appears in,
+    // which is one frame before the effect can start the request.
+    isLoading: address !== null && balances === null && error === null,
+    isRefreshing: isRefreshRequested && balances !== null,
+    error,
+    isUnfunded,
+    refresh,
+  };
+}

--- a/src/services/stellar.service.ts
+++ b/src/services/stellar.service.ts
@@ -1,0 +1,176 @@
+/**
+ * Stellar Horizon Client
+ *
+ * A minimal REST wrapper around the Horizon endpoints the frontend needs.
+ * Deliberately does not use `@stellar/stellar-sdk`: the SDK is not a direct
+ * dependency of this app (it only exists as transitive copies under the wallet
+ * kit), reading balances is a single `GET /accounts/{id}`, and owning the
+ * transport keeps the T3 Horizon -> Stellar RPC migration (D3.1) local to this
+ * file.
+ */
+
+import { HORIZON_URL, STELLAR_EXPLORER_URL, USDC_ASSET_CODE, USDC_ISSUER } from "@/config/wallet";
+import type { StellarAccountBalances, StellarAssetBalance } from "@/types/wallet.types";
+
+export const XLM_ASSET_CODE = "XLM";
+
+/**
+ * Horizon has no record of the account. On Stellar this is the normal state of
+ * a keypair that has never been funded, not a failure.
+ */
+export class StellarAccountNotFoundError extends Error {
+  readonly accountId: string;
+
+  constructor(accountId: string) {
+    super(`Stellar account ${accountId} does not exist on this network.`);
+    this.name = "StellarAccountNotFoundError";
+    this.accountId = accountId;
+  }
+}
+
+/** Horizon was reachable but answered with something unusable. */
+export class HorizonRequestError extends Error {
+  readonly status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = "HorizonRequestError";
+    this.status = status;
+  }
+}
+
+export interface FetchAccountBalancesOptions {
+  /** Aborts the in-flight request, e.g. when the connected wallet changes. */
+  signal?: AbortSignal;
+}
+
+/**
+ * A single entry of Horizon's `balances[]` array, narrowed to the fields used
+ * here. Liquidity pool shares carry `liquidity_pool_id` instead of an asset
+ * code and are ignored by the matchers below.
+ */
+interface HorizonBalanceLine {
+  asset_type: string;
+  balance: string;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isHorizonBalanceLine(value: unknown): value is HorizonBalanceLine {
+  return (
+    isRecord(value) && typeof value.asset_type === "string" && typeof value.balance === "string"
+  );
+}
+
+/**
+ * Pulls the usable balance lines out of an untrusted Horizon payload. Anything
+ * that does not match the expected shape is dropped rather than crashing the
+ * card — a malformed line must not hide the rest of the balances.
+ */
+function readBalanceLines(payload: unknown): HorizonBalanceLine[] {
+  if (!isRecord(payload) || !Array.isArray(payload.balances)) {
+    throw new HorizonRequestError("Horizon returned an account without a balances list.");
+  }
+
+  return payload.balances.filter(isHorizonBalanceLine).map((line) => ({
+    asset_type: line.asset_type,
+    balance: line.balance,
+    asset_code: readOptionalString(line.asset_code),
+    asset_issuer: readOptionalString(line.asset_issuer),
+  }));
+}
+
+function missingAsset(code: string): StellarAssetBalance {
+  return { code, balance: "0", hasTrustline: false };
+}
+
+/** Balances of a keypair Horizon has never seen: nothing held, nothing trusted. */
+export function emptyAccountBalances(): StellarAccountBalances {
+  return {
+    xlm: missingAsset(XLM_ASSET_CODE),
+    usdc: missingAsset(USDC_ASSET_CODE),
+  };
+}
+
+function selectXlm(lines: HorizonBalanceLine[]): StellarAssetBalance {
+  const native = lines.find((line) => line.asset_type === "native");
+  if (native === undefined) {
+    return missingAsset(XLM_ASSET_CODE);
+  }
+  return { code: XLM_ASSET_CODE, balance: native.balance, hasTrustline: true };
+}
+
+function selectUsdc(lines: HorizonBalanceLine[]): StellarAssetBalance {
+  // Code alone is not an identity — any account can issue an asset named USDC.
+  const usdc = lines.find(
+    (line) => line.asset_code === USDC_ASSET_CODE && line.asset_issuer === USDC_ISSUER
+  );
+  if (usdc === undefined) {
+    return missingAsset(USDC_ASSET_CODE);
+  }
+  return { code: USDC_ASSET_CODE, balance: usdc.balance, hasTrustline: true };
+}
+
+/**
+ * Reads the XLM and USDC balances of a Stellar account from Horizon.
+ *
+ * @throws {StellarAccountNotFoundError} when the account is not funded on this network
+ * @throws {HorizonRequestError} when Horizon is unreachable or answers unusably
+ */
+export async function fetchAccountBalances(
+  accountId: string,
+  options: FetchAccountBalancesOptions = {}
+): Promise<StellarAccountBalances> {
+  const url = `${HORIZON_URL}/accounts/${encodeURIComponent(accountId)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: options.signal,
+      cache: "no-store",
+    });
+  } catch (cause) {
+    // Rethrow aborts untouched so callers can tell "cancelled" from "failed".
+    if (cause instanceof DOMException && cause.name === "AbortError") {
+      throw cause;
+    }
+    throw new HorizonRequestError("Could not reach Horizon.");
+  }
+
+  if (response.status === 404) {
+    throw new StellarAccountNotFoundError(accountId);
+  }
+
+  if (!response.ok) {
+    throw new HorizonRequestError(`Horizon responded with ${response.status}.`, response.status);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new HorizonRequestError("Horizon returned a malformed response.", response.status);
+  }
+
+  const lines = readBalanceLines(payload);
+
+  return {
+    xlm: selectXlm(lines),
+    usdc: selectUsdc(lines),
+  };
+}
+
+/** Explorer page for an account on the active network, for manual verification. */
+export function buildAccountExplorerUrl(accountId: string): string {
+  return `${STELLAR_EXPLORER_URL}/account/${encodeURIComponent(accountId)}`;
+}

--- a/src/types/wallet.types.ts
+++ b/src/types/wallet.types.ts
@@ -23,6 +23,30 @@ export interface WalletConnectionState {
   disconnectWallet: () => void;
 }
 
+/**
+ * One asset line of a Stellar account, normalized from Horizon's `balances[]`.
+ *
+ * Amounts stay strings: Horizon reports 7-decimal fixed point and `number`
+ * cannot round-trip large balances exactly. Convert only for display.
+ */
+export interface StellarAssetBalance {
+  /** Display code, e.g. "XLM" or "USDC". */
+  code: string;
+  /** Balance as Horizon reports it, e.g. "9974.9999800". "0" without a trustline. */
+  balance: string;
+  /**
+   * False when the account holds no trustline for this asset. Always true for
+   * XLM, which every funded account holds natively.
+   */
+  hasTrustline: boolean;
+}
+
+/** XLM and USDC balances of a single Stellar account. */
+export interface StellarAccountBalances {
+  xlm: StellarAssetBalance;
+  usdc: StellarAssetBalance;
+}
+
 export interface WalletKitContextValue {
   /** True once SWK has been initialized in the browser. False during SSR and first paint. */
   isReady: boolean;


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat: XLM + USDC balance display from connected wallet (Horizon)

## 🛠️ Issue

- Closes #323

## 📚 Description

Fetches and displays the real XLM and USDC balance from Horizon for the connected wallet — required for SCF D1.1 verification.

Branched from `main`, **not** from #336. The two touch disjoint files; the only shared file is the `components/wallet` barrel, one export line each.

### No `@stellar/stellar-sdk` — deliberate

Plain `fetch` against the Horizon REST API. The SDK resolves to **four transitive copies** in this tree (13.3.0 hoisted, 16.2.0 under the wallet kit, 14.2.0 twice under trezor) and is **not a direct dependency**. Importing it would silently bind to the hoisted 13.3.0, which hangs off `trezor-connect-plugin-stellar` — a sub-sub-dependency any lockfile dedupe can move or drop.

Reading two balances is a single `GET /accounts/{id}`. Owning the transport also keeps the T3 Horizon → Stellar RPC migration (D3.1) local to one file. **No dependencies added.**

### Three things that are easy to get wrong

**USDC is matched on `asset_code` AND `asset_issuer`.** Any account can issue an asset called USDC, and testnet has a real lookalike — an account holding `USDCAllow` from an unrelated issuer. A code-prefix match would have reported it as the user's USDC balance.

**Amounts stay strings end to end.** Horizon's seven-decimal fixed point does not round-trip through a JavaScript number.

**`Intl.NumberFormat` is used without `style: "currency"`.** Neither XLM nor USDC is an ISO 4217 code, so that option throws. The existing card used it for the fiat figures; the new section formats with min 2 / max 7 fraction digits instead.

### Config

Defaults derive from `STELLAR_NETWORK` so the Horizon endpoint and the USDC issuer can never disagree with the network the wallet kit signs against. Both env overrides are validated before use — the URL must parse as http(s), the issuer must match a Stellar public key pattern — following the file's existing rule that a malformed variable falls back to the safe default rather than silently pointing somewhere unintended.

| | testnet | public |
|---|---|---|
| Horizon | `horizon-testnet.stellar.org` | `horizon.stellar.org` |
| USDC issuer | `GBBD47IF…3ZLLFLA5` | `GA5ZSEJY…E34K4KZVN` |

New optional vars, documented in `.env.example`: `NEXT_PUBLIC_STELLAR_HORIZON_URL`, `NEXT_PUBLIC_STELLAR_USDC_ISSUER`.

### State handling

`balances` and `error` are keyed internally to the address they belong to, so switching wallets cannot flash the previous wallet's numbers. Only one request is ever in flight — a new load aborts the previous controller, and the effect cleanup aborts on unmount — so a fast reconnect cannot resolve out of order. Before the store rehydrates the address is treated as unknown, not disconnected.

A 404 from Horizon means an unfunded keypair, which is a normal state on Stellar, so it renders as an explicit notice with zeroes rather than as an error.

## ✅ Changes applied

Five atomic commits:

| Commit | Change |
|---|---|
| `feat(config)` | Horizon, explorer and USDC configuration + `.env.example` |
| `feat(services)` | `stellar.service.ts` Horizon REST client + balance types |
| `feat(hooks)` | `useWalletBalance` |
| `feat(wallet)` | `WalletAssetBalances` section; `BalanceCard` optional `externalWallet` prop |
| `feat(wallet)` | Wallet page wiring |

`BalanceCard`'s new prop is **optional and additive** — the existing call site keeps its `{ available, reserved, currency }` contract and renders identically when omitted.

Accessibility: `role="status"` with an sr-only label on the skeleton, `role="alert"` with a Try again action on the error, `aria-busy` on the section during refresh, `useId`-scoped heading.

## 🔍 Evidence/Media (screenshots/videos)

**Verified against live Horizon testnet** — raw API response next to the parsed output:

```
GDZZUVIQPMEDHJ67Y6UFEWZRWFOY6VLCR7ESMABF5R6MLARMCJJ7LJAC   HTTP 200
  native            → 9974.9999800
  USDC / GBBD47IF…  → 25.7438818
  parsed: {"xlm":{"balance":"9974.9999800","hasTrustline":true},
           "usdc":{"balance":"25.7438818","hasTrustline":true}}

GBBD47IF…  (holds USDCAllow from an unrelated issuer)        HTTP 200
  parsed: usdc → {"balance":"0","hasTrustline":false}   ← lookalike correctly rejected

GBBSEPMM…  (never funded)                                    HTTP 404
  → StellarAccountNotFoundError, rendered as zeroes
```

**Gates:**
```
$ npx tsc --noEmit          exit 0
$ npm run build             exit 0
$ npx eslint .              ✖ 91 problems (86 errors, 5 warnings)
```

The 91 are **identical to the baseline at `main`** — zero new problems, none of the pre-existing ones fixed. New files are Prettier-clean; the two modified files that fail `format:check` already failed at `HEAD` and were not reformatted (305 files fail repo-wide).

**No test suite exists in this repo** — no vitest or jest config, no `*.test.*` / `*.spec.*` files, no test script. Nothing was removed; there was never a harness. `npm run build` is the strongest available automated gate.

### Two limits worth knowing

1. **The "confirmed against testnet explorer" criterion is only partially met.** Verification above is against the Horizon REST API, not the stellar.expert UI. **Human confirmation in the explorer is still required for the SCF D1.1 demo.** The card renders a per-account explorer link to make that one click.
2. **This branch has no UI that sets `walletAddress`** — that is #336's `WalletConnectButton`. The section is therefore inert here until that lands, by design. To exercise it before then, seed `walletAddress` / `walletConnected` into the `auth-state` localStorage entry.
