### PR TITLE
feat: wallet sign-in flow — challenge → SWK sign → verify → JWT

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,6 +9,7 @@ import {
   AuthInput,
   AuthDivider,
 } from "@/components/auth";
+import { WalletSignInButton } from "@/components/auth/WalletSignInButton";
 import { cn } from "@/lib/cn";
 import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
@@ -67,6 +68,17 @@ function LoginContent() {
     }
   };
 
+  /**
+   * Where a successful sign-in lands, whatever proved the identity.
+   * Shared so wallet auth cannot drift from the email path.
+   */
+  const goToDashboard = () => {
+    const defaultDashboard =
+      mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
+
+    router.push(redirectPath || defaultDashboard);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -106,10 +118,7 @@ function LoginContent() {
 
       setIsLoading(false);
 
-      const defaultDashboard =
-        mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
-
-      router.push(redirectPath || defaultDashboard);
+      goToDashboard();
     } catch (error) {
       console.error("Login error:", error);
       setErrors({ email: "Connection error. Please try again." });
@@ -152,6 +161,11 @@ function LoginContent() {
       {/* Social Auth */}
       <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}>
         <SocialAuthButtons />
+      </div>
+
+      {/* Wallet Auth — D1.2 challenge-response, same session as an email login */}
+      <div className="mt-3 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.12s", animationFillMode: "forwards" }}>
+        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Divider */}

--- a/src/components/auth/WalletSignInButton.tsx
+++ b/src/components/auth/WalletSignInButton.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { StellarIcon } from "@/components/ui/StellarIcon";
+import { LoadingSpinner } from "@/components/ui/Icon";
+import { WalletConnectModal } from "@/components/wallet/WalletConnectModal";
+import { useWalletKit } from "@/hooks/use-wallet-kit";
+import { useWalletAuth, type WalletAuthStep } from "@/hooks/useWalletAuth";
+
+export interface WalletSignInButtonProps {
+  /** Called once the wallet session is stored, so the page can redirect. */
+  onSignedIn?: () => void;
+  /** Mirrors the other auth buttons while an email login is in flight. */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * What the user is actually waiting on.
+ *
+ * The signing step blocks on the wallet's own confirmation popup, which is
+ * easily missed behind the browser window — naming it is the difference between
+ * waiting and knowing to go look.
+ */
+const STEP_LABEL: Record<Exclude<WalletAuthStep, "idle">, string> = {
+  "requesting-challenge": "Preparing sign-in...",
+  signing: "Check your wallet to sign",
+  verifying: "Verifying signature...",
+};
+
+/**
+ * Sign in with a Stellar wallet — the D1.2 challenge-response flow.
+ *
+ * With no wallet connected the click opens `WalletConnectModal` and the flow
+ * continues from its `onConnected`, so connecting and signing in read as one
+ * action rather than two.
+ */
+export function WalletSignInButton({
+  onSignedIn,
+  disabled = false,
+  className,
+}: WalletSignInButtonProps): React.JSX.Element {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { address } = useWalletKit();
+  const { signIn, step, isAuthenticating, error, reset } = useWalletAuth();
+
+  async function runSignIn(publicKey: string): Promise<void> {
+    const session = await signIn(publicKey);
+    if (session !== null) {
+      onSignedIn?.();
+    }
+  }
+
+  async function handleClick(): Promise<void> {
+    reset();
+
+    if (address === null) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    await runSignIn(address);
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || isAuthenticating}
+        aria-busy={isAuthenticating}
+        className={cn(
+          "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl",
+          "bg-white border border-border-light cursor-pointer",
+          "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+          "hover:shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff] hover:scale-[1.02]",
+          "active:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff] active:scale-[0.98]",
+          "transition-all duration-200",
+          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+        )}
+      >
+        {isAuthenticating ? (
+          <LoadingSpinner size="sm" />
+        ) : (
+          <span className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+            <StellarIcon className="text-primary" />
+          </span>
+        )}
+        <span className="text-sm font-medium text-text-primary">
+          {step === "idle" ? "Continue with wallet" : STEP_LABEL[step]}
+        </span>
+      </button>
+
+      {/* Announced rather than only shown: the failure often happens while the
+          user is looking at the wallet popup, not at this page. */}
+      {error !== null && (
+        <p role="alert" className="text-xs text-error px-1">
+          {error}
+        </p>
+      )}
+
+      <WalletConnectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConnected={(connected) => {
+          setIsModalOpen(false);
+          void runSignIn(connected);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useWalletAuth.ts
+++ b/src/hooks/useWalletAuth.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  requestChallenge,
+  verifySignature,
+  WalletAuthError,
+  type WalletSession,
+} from "@/services/wallet-auth.service";
+
+/**
+ * Where the flow currently is. Each value maps to a distinct thing the user is
+ * waiting on, so the UI can say "check your wallet" instead of a generic spinner
+ * — the signing step is the one that blocks on a browser extension popup and is
+ * by far the slowest.
+ */
+export type WalletAuthStep = "idle" | "requesting-challenge" | "signing" | "verifying";
+
+export interface UseWalletAuthResult {
+  /** Run challenge → sign → verify → store. Resolves to the session, or null on failure. */
+  signIn: (publicKey: string) => Promise<WalletSession | null>;
+  step: WalletAuthStep;
+  isAuthenticating: boolean;
+  error: string | null;
+  /** Clear a previous failure, e.g. when the user reopens the dialog. */
+  reset: () => void;
+}
+
+/**
+ * Message shown for a given failure.
+ *
+ * The API's own message is used when it is safe and specific; the cases below
+ * are the ones where it is either too terse or describes a server-side concept
+ * the user has no way to act on.
+ */
+function toUserMessage(error: unknown): string {
+  if (error instanceof WalletAuthError) {
+    switch (error.code) {
+      case "WALLET_CHALLENGE_EXPIRED":
+        return "The sign-in request expired. Please try again.";
+      case "WALLET_CHALLENGE_MISMATCH":
+      case "INVALID_SIGNATURE_FORMAT":
+        return "That signature could not be verified. Please try signing again.";
+      case "NETWORK_ERROR":
+      case "MALFORMED_RESPONSE":
+        return error.message;
+      default:
+        return error.message;
+    }
+  }
+
+  // Wallet kits reject with plain objects as often as with Errors, and a user
+  // declining the signature prompt lands here.
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const { message } = error as { message: unknown };
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+
+  return "Could not sign in with your wallet. Please try again.";
+}
+
+/**
+ * Wallet sign-in: request a nonce, sign it with the connected wallet, exchange
+ * the signature for a JWT, and store the session exactly as an email login does.
+ */
+export function useWalletAuth(): UseWalletAuthResult {
+  const [step, setStep] = useState<WalletAuthStep>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const login = useAuthStore((state) => state.login);
+  const connectWallet = useAuthStore((state) => state.connectWallet);
+
+  // Guards against a double-submit racing itself: two flows would each burn a
+  // nonce, and the loser's signature would verify against an already-consumed
+  // challenge.
+  const inFlight = useRef(false);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setStep("idle");
+  }, []);
+
+  const signIn = useCallback(
+    async (publicKey: string): Promise<WalletSession | null> => {
+      if (inFlight.current) {
+        return null;
+      }
+
+      inFlight.current = true;
+      setError(null);
+
+      try {
+        setStep("requesting-challenge");
+        const { challenge } = await requestChallenge(publicKey);
+
+        setStep("signing");
+        // Blocks on the wallet's own confirmation UI. `address` pins the request
+        // to the key we asked a challenge for, in case the wallet holds several.
+        const { signedMessage } = await StellarWalletsKit.signMessage(challenge, {
+          address: publicKey,
+        });
+
+        setStep("verifying");
+        const session = await verifySignature(publicKey, signedMessage, challenge);
+
+        // Same store transition as an email login, plus the wallet slice so the
+        // navbar and balance card see the address without re-reading the kit.
+        login(session.user, session.token);
+        connectWallet(publicKey);
+
+        setStep("idle");
+        return session;
+      } catch (cause) {
+        setError(toUserMessage(cause));
+        setStep("idle");
+        return null;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [login, connectWallet]
+  );
+
+  return {
+    signIn,
+    step,
+    isAuthenticating: step !== "idle",
+    error,
+    reset,
+  };
+}

--- a/src/services/wallet-auth.service.ts
+++ b/src/services/wallet-auth.service.ts
@@ -1,0 +1,185 @@
+/**
+ * Wallet Authentication Service
+ *
+ * Client half of the D1.2 challenge-response flow: ask the API for a nonce,
+ * sign it in the user's wallet, hand the signature back for a JWT.
+ *
+ * Uses `fetch` directly rather than `./http-client`, which types every response
+ * as `ApiResponse` (`ok`, `code`, `title`, …). This API answers with the
+ * `{ data }` / `{ error }` envelope instead, so `ApiResponse.ok` would read as
+ * `undefined` and a successful call would look like a failure. The `lib/api/*`
+ * modules talk to the same backend the same way.
+ */
+
+import { API_URL } from "@/config/api";
+import type { User } from "@/stores/auth-store";
+
+/** A nonce to sign, and how long the API will keep accepting it. */
+export interface WalletChallenge {
+  challenge: string;
+  expiresIn: number;
+}
+
+/** A verified wallet session: the same pair an email login produces. */
+export interface WalletSession {
+  user: User;
+  token: string;
+}
+
+/**
+ * A failed wallet-auth call, carrying the API's own error code so callers can
+ * react to specific cases (an expired nonce is worth retrying; a mismatched
+ * signature is not).
+ */
+export class WalletAuthError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = "WalletAuthError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Pull the API's `{ error: { code, message } }` out of a failed response.
+ *
+ * Falls back to the HTTP status when the body is missing or unparseable — a 502
+ * from a proxy never reaches the application error envelope.
+ */
+async function toWalletAuthError(response: Response): Promise<WalletAuthError> {
+  let code = "UNKNOWN_ERROR";
+  let message = `Request failed with status ${response.status}.`;
+
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && isRecord(payload.error)) {
+      code = readString(payload.error.code) ?? code;
+      message = readString(payload.error.message) ?? message;
+    }
+  } catch {
+    // Body was not JSON; the status-based defaults above stand.
+  }
+
+  return new WalletAuthError(message, code, response.status);
+}
+
+async function postJson(path: string, body: unknown): Promise<unknown> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_URL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new WalletAuthError(
+      "Could not reach the server. Check your connection and try again.",
+      "NETWORK_ERROR",
+      0
+    );
+  }
+
+  if (!response.ok) {
+    throw await toWalletAuthError(response);
+  }
+
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || payload.data === undefined) {
+    throw new WalletAuthError(
+      "The server returned an unexpected response.",
+      "MALFORMED_RESPONSE",
+      response.status
+    );
+  }
+
+  return payload.data;
+}
+
+/**
+ * Ask the API for a nonce bound to `publicKey`.
+ *
+ * Public endpoint — ownership has not been proven yet, which is what the
+ * signature in {@link verifySignature} is for.
+ */
+export async function requestChallenge(publicKey: string): Promise<WalletChallenge> {
+  const data = await postJson("/auth/wallet/challenge", { publicKey });
+
+  if (!isRecord(data) || typeof data.challenge !== "string") {
+    throw new WalletAuthError(
+      "The server did not return a challenge to sign.",
+      "MALFORMED_RESPONSE",
+      200
+    );
+  }
+
+  return {
+    challenge: data.challenge,
+    expiresIn: typeof data.expiresIn === "number" ? data.expiresIn : 0,
+  };
+}
+
+/**
+ * Exchange a signed challenge for a session.
+ *
+ * `challenge` is a parameter rather than state held here because the API
+ * verifies the signature against the exact nonce it issued, and the nonce is
+ * consumed on success — a second attempt needs a fresh one from
+ * {@link requestChallenge}.
+ */
+export async function verifySignature(
+  publicKey: string,
+  signature: string,
+  challenge: string
+): Promise<WalletSession> {
+  const data = await postJson("/auth/wallet/verify", { publicKey, signature, challenge });
+
+  if (!isRecord(data) || typeof data.token !== "string" || !isRecord(data.user)) {
+    throw new WalletAuthError("The server did not return a session.", "MALFORMED_RESPONSE", 200);
+  }
+
+  return { user: toUser(data.user), token: data.token };
+}
+
+const USER_TYPES = ["BUYER", "SELLER", "BOTH", "ADMIN"] as const;
+type UserType = (typeof USER_TYPES)[number];
+
+function toUserType(value: unknown): UserType | undefined {
+  return USER_TYPES.find((candidate) => candidate === value);
+}
+
+/**
+ * Narrow the API's user payload onto the store's `User`.
+ *
+ * `email` is nullable server-side (a wallet-first account may never have one)
+ * but required by the store, so it collapses to an empty string rather than
+ * being dropped — the store's consumers render it, they do not authenticate
+ * with it.
+ */
+function toUser(payload: Record<string, unknown>): User {
+  const wallet = isRecord(payload.wallet) ? payload.wallet : null;
+
+  return {
+    id: String(payload.id),
+    email: readString(payload.email) ?? "",
+    username: readString(payload.username) ?? String(payload.id),
+    firstName: readString(payload.firstName),
+    lastName: readString(payload.lastName),
+    type: toUserType(payload.type),
+    wallet:
+      wallet && typeof wallet.publicKey === "string"
+        ? { publicKey: wallet.publicKey, type: readString(wallet.type) ?? "EXTERNAL" }
+        : undefined,
+  };
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat: wallet sign-in flow — challenge → SWK sign → verify → JWT

## 🛠️ Issue

- Closes #324

## 📚 Description

Client half of the D1.2 challenge-response auth: request a nonce from the API, sign it with the connected wallet, exchange the signature for a JWT, and store the session exactly as an email login does.

Entry point is the login page, alongside the OAuth buttons. With no wallet connected the click opens the existing `WalletConnectModal` and the flow resumes from its `onConnected`, so connecting and signing in read as one action rather than two.

### Found and fixed a blocking API bug on the way

`POST /auth/wallet/verify` returned **500 for every first-time wallet**, so this flow could never complete. Root cause was a null `Wallet.id` in `findOrCreateUserByWallet`. Filed as OFFER-HUB-API#140 and fixed in OFFER-HUB-API#141, which is merged — this PR is verified against the fixed API.

It was invisible to the API's own test suite because those specs run against an in-memory Prisma double that does not enforce column constraints. It only surfaced by driving the real endpoints.

### Why not `services/http-client.ts`

The service uses `fetch` directly. `http-client` types every response as `ApiResponse` (`ok`, `code`, `type`, `title`, `message`) and casts the parsed body to it, but this API answers with the `{ data }` / `{ error }` envelope. `ApiResponse.ok` would therefore read as `undefined` on a perfectly good 200, and a successful sign-in would be treated as a failure. Every module in `lib/api/*` talks to the same backend the same way — plain `fetch`, read `.data`.

### Deviation from the AC — needs sign-off

The AC specifies `verifySignature(publicKey, signature)`, but the API verifies the signature against the exact nonce it issued and requires `challenge` in the body. The signature alone is not verifiable, so the function takes `(publicKey, signature, challenge)`. Same shape as `/wallet/connect` and `/wallet/claim`.

`challenge` is a parameter rather than state held inside the service because the nonce is consumed on success — a retry needs a fresh one from `requestChallenge`, and hiding that in module state would make a stale nonce look like a signature failure.

### Details worth a reviewer's eye

**A ref guards the double submit.** Two concurrent flows would each burn a nonce, and the loser's signature would verify against an already-consumed challenge — a confusing "invalid signature" for what is really a race.

**Steps are named, not spinners.** `signing` blocks on the wallet's own confirmation popup, which is easily missed behind the browser window; the button says *"Check your wallet to sign"* rather than showing an opaque spinner. Errors render in a `role="alert"` for the same reason — the failure usually happens while the user is looking at the wallet, not the page.

**The user payload is narrowed, not cast.** `email` is nullable server-side (a wallet-first account never has one) and collapses to an empty string for the store, whose consumers render it but do not authenticate with it. `type` is checked against the store's union rather than trusted.

**The post-login redirect was extracted** into `goToDashboard()` so wallet auth cannot drift from the email path.

## ✅ Changes applied

Three atomic commits:

| Commit | Change |
|---|---|
| `feat(services)` | `wallet-auth.service.ts` — `requestChallenge`, `verifySignature`, `WalletAuthError` |
| `feat(hooks)` | `useWalletAuth` — orchestration, per-step state, double-submit guard |
| `feat(auth)` | `WalletSignInButton` + login page wiring, redirect extracted |

No new dependencies. No `any`.

## 🔍 Evidence/Media (screenshots/videos)

https://github.com/user-attachments/assets/81923981-d6d2-4093-a182-92bc2ff9256d



The replay case confirms the error envelope the service parses, and that a consumed nonce surfaces as `WALLET_CHALLENGE_EXPIRED` — which the hook maps to *"The sign-in request expired. Please try again."*

**Gates:**

```
$ npx tsc --noEmit    exit 0
$ npm run build       exit 0
$ npx eslint .        ✖ 91 problems (86 errors, 5 warnings)
```

The 91 are **identical to the baseline at `main`** — zero new. All three new files are Prettier-clean; no existing file was reformatted.

### Not covered

- **No test suite exists in this repo** — no vitest or jest config, no `*.test.*` files, no test script. `npm run build` plus the live contract check above are the strongest gates available.
- **The browser half is unexercised.** `StellarWalletsKit.signMessage()` was not driven through a real extension — the contract check signs with a keypair, which is what the wallet produces, but the popup interaction itself needs a human with Freighter installed. Worth confirming before the SCF D1.2 demo, since `signedMessage` encoding is the one thing that could differ per wallet.
