### PR TITLE
feat: hybrid login UI — wallet tab + email/password tab

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,6 +9,7 @@ import {
   AuthInput,
   AuthDivider,
 } from "@/components/auth";
+import { WalletSignInButton } from "@/components/auth/WalletSignInButton";
 import { cn } from "@/lib/cn";
 import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
@@ -67,6 +68,17 @@ function LoginContent() {
     }
   };
 
+  /**
+   * Where a successful sign-in lands, whatever proved the identity.
+   * Shared so wallet auth cannot drift from the email path.
+   */
+  const goToDashboard = () => {
+    const defaultDashboard =
+      mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
+
+    router.push(redirectPath || defaultDashboard);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -106,10 +118,7 @@ function LoginContent() {
 
       setIsLoading(false);
 
-      const defaultDashboard =
-        mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
-
-      router.push(redirectPath || defaultDashboard);
+      goToDashboard();
     } catch (error) {
       console.error("Login error:", error);
       setErrors({ email: "Connection error. Please try again." });
@@ -152,6 +161,11 @@ function LoginContent() {
       {/* Social Auth */}
       <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}>
         <SocialAuthButtons />
+      </div>
+
+      {/* Wallet Auth — D1.2 challenge-response, same session as an email login */}
+      <div className="mt-3 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.12s", animationFillMode: "forwards" }}>
+        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Divider */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,7 +10,9 @@ import {
   AuthDivider,
 } from "@/components/auth";
 import { WalletSignInButton } from "@/components/auth/WalletSignInButton";
+import { StellarIcon } from "@/components/ui/StellarIcon";
 import { cn } from "@/lib/cn";
+import { NEUMORPHIC_INSET } from "@/lib/styles";
 import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
 import type { LoginFormData, AuthFormErrors } from "@/types/auth.types";
@@ -231,12 +233,37 @@ function LoginContent() {
         id="auth-panel-wallet"
         aria-labelledby="auth-tab-wallet"
         hidden={activeTab !== "wallet"}
+        // Roughly the height of the email panel, so switching tabs does not
+        // collapse the card and shove the footer links up the page.
+        className="min-h-[22rem] flex flex-col justify-center"
       >
-        <p className="text-sm text-text-secondary text-center mb-3">
-          Connect a Stellar wallet and sign a one-time message to prove it is yours.
-          No password needed.
+        <div className={cn(NEUMORPHIC_INSET, "rounded-2xl p-6 text-center")}>
+          <span
+            className={cn(
+              "mx-auto mb-4 w-14 h-14 rounded-2xl flex items-center justify-center",
+              "bg-primary text-white",
+              "shadow-[4px_4px_8px_#d1d5db,-2px_-2px_6px_#ffffff]"
+            )}
+          >
+            <StellarIcon className="w-7 h-7" />
+          </span>
+
+          <h2 className="text-base font-semibold text-text-primary mb-1.5">
+            Sign in with your Stellar wallet
+          </h2>
+          <p className="text-sm text-text-secondary leading-relaxed">
+            Approve a one-time signature to prove the wallet is yours. No password,
+            and your keys never leave the wallet.
+          </p>
+        </div>
+
+        <div className="mt-4">
+          <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
+        </div>
+
+        <p className="text-xs text-text-secondary text-center mt-3">
+          Works with Freighter, Lobstr and xBull
         </p>
-        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Email panel — the pre-existing sign-in experience, unchanged */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -15,6 +15,13 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
 import type { LoginFormData, AuthFormErrors } from "@/types/auth.types";
 
+type AuthTabId = "email" | "wallet";
+
+const AUTH_TABS: ReadonlyArray<{ id: AuthTabId; label: string }> = [
+  { id: "email", label: "Email / Password" },
+  { id: "wallet", label: "Connect Wallet" },
+];
+
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -29,6 +36,26 @@ function LoginContent() {
   });
   const [errors, setErrors] = useState<AuthFormErrors>({});
   const [redirectPath, setRedirectPath] = useState<string | null>(null);
+  // Email stays the default: it is what every existing account uses, and the
+  // wallet path is additive rather than a replacement.
+  const [activeTab, setActiveTab] = useState<AuthTabId>("email");
+
+  /**
+   * Arrow keys move between tabs, as a tablist is expected to behave — only the
+   * selected tab is in the Tab order, so without this the second one would be
+   * unreachable by keyboard.
+   */
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+
+    e.preventDefault();
+    const current = AUTH_TABS.findIndex((t) => t.id === activeTab);
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = AUTH_TABS[(current + delta + AUTH_TABS.length) % AUTH_TABS.length];
+
+    setActiveTab(next.id);
+    document.getElementById(`auth-tab-${next.id}`)?.focus();
+  };
 
   useEffect(() => {
     if (searchParams.get("registered") === "true") {
@@ -158,14 +185,70 @@ function LoginContent() {
         </p>
       </div>
 
+      {/* Method tabs */}
+      <div
+        role="tablist"
+        aria-label="Sign-in method"
+        onKeyDown={handleTabKeyDown}
+        className={cn(
+          "flex gap-2 p-1 rounded-2xl bg-background mb-4",
+          "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+          "opacity-0 animate-fade-in-up"
+        )}
+        style={{ animationDelay: "0.08s", animationFillMode: "forwards" }}
+      >
+        {AUTH_TABS.map(({ id, label }) => {
+          const active = activeTab === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              id={`auth-tab-${id}`}
+              aria-selected={active}
+              aria-controls={`auth-panel-${id}`}
+              // Only the selected tab is reachable by Tab; the arrow keys move
+              // between them, which is how a tablist is meant to behave.
+              tabIndex={active ? 0 : -1}
+              onClick={() => setActiveTab(id)}
+              className={cn(
+                "flex-1 px-3 py-2.5 rounded-xl text-sm font-medium transition-all cursor-pointer",
+                "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
+                active
+                  ? "bg-primary text-white shadow-[2px_2px_6px_#d1d5db]"
+                  : "text-text-secondary hover:text-text-primary"
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Wallet panel */}
+      <div
+        role="tabpanel"
+        id="auth-panel-wallet"
+        aria-labelledby="auth-tab-wallet"
+        hidden={activeTab !== "wallet"}
+      >
+        <p className="text-sm text-text-secondary text-center mb-3">
+          Connect a Stellar wallet and sign a one-time message to prove it is yours.
+          No password needed.
+        </p>
+        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
+      </div>
+
+      {/* Email panel — the pre-existing sign-in experience, unchanged */}
+      <div
+        role="tabpanel"
+        id="auth-panel-email"
+        aria-labelledby="auth-tab-email"
+        hidden={activeTab !== "email"}
+      >
       {/* Social Auth */}
       <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}>
         <SocialAuthButtons />
-      </div>
-
-      {/* Wallet Auth — D1.2 challenge-response, same session as an email login */}
-      <div className="mt-3 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.12s", animationFillMode: "forwards" }}>
-        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Divider */}
@@ -241,6 +324,7 @@ function LoginContent() {
           </button>
         </div>
       </form>
+      </div>
 
       {/* Register Link */}
       <p className="text-center text-sm text-text-secondary mt-4 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.35s", animationFillMode: "forwards" }}>

--- a/src/components/auth/WalletSignInButton.tsx
+++ b/src/components/auth/WalletSignInButton.tsx
@@ -70,24 +70,27 @@ export function WalletSignInButton({
         onClick={handleClick}
         disabled={disabled || isAuthenticating}
         aria-busy={isAuthenticating}
+        // The primary action of its panel, so it mirrors the email tab's submit
+        // button rather than the secondary styling of the OAuth row.
         className={cn(
-          "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl",
-          "bg-white border border-border-light cursor-pointer",
-          "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
-          "hover:shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff] hover:scale-[1.02]",
-          "active:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff] active:scale-[0.98]",
+          "w-full flex items-center justify-center gap-2.5 px-6 py-3 rounded-xl",
+          "bg-primary text-white font-medium cursor-pointer",
+          "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+          "hover:bg-primary-hover hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff] hover:scale-[1.02]",
+          "active:shadow-[inset_4px_4px_8px_rgba(0,0,0,0.2)] active:scale-[0.98]",
+          "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
           "transition-all duration-200",
-          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          "disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:scale-100"
         )}
       >
         {isAuthenticating ? (
           <LoadingSpinner size="sm" />
         ) : (
-          <span className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-            <StellarIcon className="text-primary" />
+          <span className="w-5 h-5 rounded-lg bg-white/20 flex items-center justify-center shrink-0">
+            <StellarIcon className="text-white" />
           </span>
         )}
-        <span className="text-sm font-medium text-text-primary">
+        <span className="text-sm">
           {step === "idle" ? "Continue with wallet" : STEP_LABEL[step]}
         </span>
       </button>

--- a/src/components/auth/WalletSignInButton.tsx
+++ b/src/components/auth/WalletSignInButton.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { StellarIcon } from "@/components/ui/StellarIcon";
+import { LoadingSpinner } from "@/components/ui/Icon";
+import { WalletConnectModal } from "@/components/wallet/WalletConnectModal";
+import { useWalletKit } from "@/hooks/use-wallet-kit";
+import { useWalletAuth, type WalletAuthStep } from "@/hooks/useWalletAuth";
+
+export interface WalletSignInButtonProps {
+  /** Called once the wallet session is stored, so the page can redirect. */
+  onSignedIn?: () => void;
+  /** Mirrors the other auth buttons while an email login is in flight. */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * What the user is actually waiting on.
+ *
+ * The signing step blocks on the wallet's own confirmation popup, which is
+ * easily missed behind the browser window — naming it is the difference between
+ * waiting and knowing to go look.
+ */
+const STEP_LABEL: Record<Exclude<WalletAuthStep, "idle">, string> = {
+  "requesting-challenge": "Preparing sign-in...",
+  signing: "Check your wallet to sign",
+  verifying: "Verifying signature...",
+};
+
+/**
+ * Sign in with a Stellar wallet — the D1.2 challenge-response flow.
+ *
+ * With no wallet connected the click opens `WalletConnectModal` and the flow
+ * continues from its `onConnected`, so connecting and signing in read as one
+ * action rather than two.
+ */
+export function WalletSignInButton({
+  onSignedIn,
+  disabled = false,
+  className,
+}: WalletSignInButtonProps): React.JSX.Element {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { address } = useWalletKit();
+  const { signIn, step, isAuthenticating, error, reset } = useWalletAuth();
+
+  async function runSignIn(publicKey: string): Promise<void> {
+    const session = await signIn(publicKey);
+    if (session !== null) {
+      onSignedIn?.();
+    }
+  }
+
+  async function handleClick(): Promise<void> {
+    reset();
+
+    if (address === null) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    await runSignIn(address);
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || isAuthenticating}
+        aria-busy={isAuthenticating}
+        className={cn(
+          "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl",
+          "bg-white border border-border-light cursor-pointer",
+          "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+          "hover:shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff] hover:scale-[1.02]",
+          "active:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff] active:scale-[0.98]",
+          "transition-all duration-200",
+          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+        )}
+      >
+        {isAuthenticating ? (
+          <LoadingSpinner size="sm" />
+        ) : (
+          <span className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+            <StellarIcon className="text-primary" />
+          </span>
+        )}
+        <span className="text-sm font-medium text-text-primary">
+          {step === "idle" ? "Continue with wallet" : STEP_LABEL[step]}
+        </span>
+      </button>
+
+      {/* Announced rather than only shown: the failure often happens while the
+          user is looking at the wallet popup, not at this page. */}
+      {error !== null && (
+        <p role="alert" className="text-xs text-error px-1">
+          {error}
+        </p>
+      )}
+
+      <WalletConnectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConnected={(connected) => {
+          setIsModalOpen(false);
+          void runSignIn(connected);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useWalletAuth.ts
+++ b/src/hooks/useWalletAuth.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  requestChallenge,
+  verifySignature,
+  WalletAuthError,
+  type WalletSession,
+} from "@/services/wallet-auth.service";
+
+/**
+ * Where the flow currently is. Each value maps to a distinct thing the user is
+ * waiting on, so the UI can say "check your wallet" instead of a generic spinner
+ * — the signing step is the one that blocks on a browser extension popup and is
+ * by far the slowest.
+ */
+export type WalletAuthStep = "idle" | "requesting-challenge" | "signing" | "verifying";
+
+export interface UseWalletAuthResult {
+  /** Run challenge → sign → verify → store. Resolves to the session, or null on failure. */
+  signIn: (publicKey: string) => Promise<WalletSession | null>;
+  step: WalletAuthStep;
+  isAuthenticating: boolean;
+  error: string | null;
+  /** Clear a previous failure, e.g. when the user reopens the dialog. */
+  reset: () => void;
+}
+
+/**
+ * Message shown for a given failure.
+ *
+ * The API's own message is used when it is safe and specific; the cases below
+ * are the ones where it is either too terse or describes a server-side concept
+ * the user has no way to act on.
+ */
+function toUserMessage(error: unknown): string {
+  if (error instanceof WalletAuthError) {
+    switch (error.code) {
+      case "WALLET_CHALLENGE_EXPIRED":
+        return "The sign-in request expired. Please try again.";
+      case "WALLET_CHALLENGE_MISMATCH":
+      case "INVALID_SIGNATURE_FORMAT":
+        return "That signature could not be verified. Please try signing again.";
+      case "NETWORK_ERROR":
+      case "MALFORMED_RESPONSE":
+        return error.message;
+      default:
+        return error.message;
+    }
+  }
+
+  // Wallet kits reject with plain objects as often as with Errors, and a user
+  // declining the signature prompt lands here.
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const { message } = error as { message: unknown };
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+
+  return "Could not sign in with your wallet. Please try again.";
+}
+
+/**
+ * Wallet sign-in: request a nonce, sign it with the connected wallet, exchange
+ * the signature for a JWT, and store the session exactly as an email login does.
+ */
+export function useWalletAuth(): UseWalletAuthResult {
+  const [step, setStep] = useState<WalletAuthStep>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const login = useAuthStore((state) => state.login);
+  const connectWallet = useAuthStore((state) => state.connectWallet);
+
+  // Guards against a double-submit racing itself: two flows would each burn a
+  // nonce, and the loser's signature would verify against an already-consumed
+  // challenge.
+  const inFlight = useRef(false);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setStep("idle");
+  }, []);
+
+  const signIn = useCallback(
+    async (publicKey: string): Promise<WalletSession | null> => {
+      if (inFlight.current) {
+        return null;
+      }
+
+      inFlight.current = true;
+      setError(null);
+
+      try {
+        setStep("requesting-challenge");
+        const { challenge } = await requestChallenge(publicKey);
+
+        setStep("signing");
+        // Blocks on the wallet's own confirmation UI. `address` pins the request
+        // to the key we asked a challenge for, in case the wallet holds several.
+        const { signedMessage } = await StellarWalletsKit.signMessage(challenge, {
+          address: publicKey,
+        });
+
+        setStep("verifying");
+        const session = await verifySignature(publicKey, signedMessage, challenge);
+
+        // Same store transition as an email login, plus the wallet slice so the
+        // navbar and balance card see the address without re-reading the kit.
+        login(session.user, session.token);
+        connectWallet(publicKey);
+
+        setStep("idle");
+        return session;
+      } catch (cause) {
+        setError(toUserMessage(cause));
+        setStep("idle");
+        return null;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [login, connectWallet]
+  );
+
+  return {
+    signIn,
+    step,
+    isAuthenticating: step !== "idle",
+    error,
+    reset,
+  };
+}

--- a/src/services/wallet-auth.service.ts
+++ b/src/services/wallet-auth.service.ts
@@ -1,0 +1,185 @@
+/**
+ * Wallet Authentication Service
+ *
+ * Client half of the D1.2 challenge-response flow: ask the API for a nonce,
+ * sign it in the user's wallet, hand the signature back for a JWT.
+ *
+ * Uses `fetch` directly rather than `./http-client`, which types every response
+ * as `ApiResponse` (`ok`, `code`, `title`, …). This API answers with the
+ * `{ data }` / `{ error }` envelope instead, so `ApiResponse.ok` would read as
+ * `undefined` and a successful call would look like a failure. The `lib/api/*`
+ * modules talk to the same backend the same way.
+ */
+
+import { API_URL } from "@/config/api";
+import type { User } from "@/stores/auth-store";
+
+/** A nonce to sign, and how long the API will keep accepting it. */
+export interface WalletChallenge {
+  challenge: string;
+  expiresIn: number;
+}
+
+/** A verified wallet session: the same pair an email login produces. */
+export interface WalletSession {
+  user: User;
+  token: string;
+}
+
+/**
+ * A failed wallet-auth call, carrying the API's own error code so callers can
+ * react to specific cases (an expired nonce is worth retrying; a mismatched
+ * signature is not).
+ */
+export class WalletAuthError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = "WalletAuthError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Pull the API's `{ error: { code, message } }` out of a failed response.
+ *
+ * Falls back to the HTTP status when the body is missing or unparseable — a 502
+ * from a proxy never reaches the application error envelope.
+ */
+async function toWalletAuthError(response: Response): Promise<WalletAuthError> {
+  let code = "UNKNOWN_ERROR";
+  let message = `Request failed with status ${response.status}.`;
+
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && isRecord(payload.error)) {
+      code = readString(payload.error.code) ?? code;
+      message = readString(payload.error.message) ?? message;
+    }
+  } catch {
+    // Body was not JSON; the status-based defaults above stand.
+  }
+
+  return new WalletAuthError(message, code, response.status);
+}
+
+async function postJson(path: string, body: unknown): Promise<unknown> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_URL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new WalletAuthError(
+      "Could not reach the server. Check your connection and try again.",
+      "NETWORK_ERROR",
+      0
+    );
+  }
+
+  if (!response.ok) {
+    throw await toWalletAuthError(response);
+  }
+
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || payload.data === undefined) {
+    throw new WalletAuthError(
+      "The server returned an unexpected response.",
+      "MALFORMED_RESPONSE",
+      response.status
+    );
+  }
+
+  return payload.data;
+}
+
+/**
+ * Ask the API for a nonce bound to `publicKey`.
+ *
+ * Public endpoint — ownership has not been proven yet, which is what the
+ * signature in {@link verifySignature} is for.
+ */
+export async function requestChallenge(publicKey: string): Promise<WalletChallenge> {
+  const data = await postJson("/auth/wallet/challenge", { publicKey });
+
+  if (!isRecord(data) || typeof data.challenge !== "string") {
+    throw new WalletAuthError(
+      "The server did not return a challenge to sign.",
+      "MALFORMED_RESPONSE",
+      200
+    );
+  }
+
+  return {
+    challenge: data.challenge,
+    expiresIn: typeof data.expiresIn === "number" ? data.expiresIn : 0,
+  };
+}
+
+/**
+ * Exchange a signed challenge for a session.
+ *
+ * `challenge` is a parameter rather than state held here because the API
+ * verifies the signature against the exact nonce it issued, and the nonce is
+ * consumed on success — a second attempt needs a fresh one from
+ * {@link requestChallenge}.
+ */
+export async function verifySignature(
+  publicKey: string,
+  signature: string,
+  challenge: string
+): Promise<WalletSession> {
+  const data = await postJson("/auth/wallet/verify", { publicKey, signature, challenge });
+
+  if (!isRecord(data) || typeof data.token !== "string" || !isRecord(data.user)) {
+    throw new WalletAuthError("The server did not return a session.", "MALFORMED_RESPONSE", 200);
+  }
+
+  return { user: toUser(data.user), token: data.token };
+}
+
+const USER_TYPES = ["BUYER", "SELLER", "BOTH", "ADMIN"] as const;
+type UserType = (typeof USER_TYPES)[number];
+
+function toUserType(value: unknown): UserType | undefined {
+  return USER_TYPES.find((candidate) => candidate === value);
+}
+
+/**
+ * Narrow the API's user payload onto the store's `User`.
+ *
+ * `email` is nullable server-side (a wallet-first account may never have one)
+ * but required by the store, so it collapses to an empty string rather than
+ * being dropped — the store's consumers render it, they do not authenticate
+ * with it.
+ */
+function toUser(payload: Record<string, unknown>): User {
+  const wallet = isRecord(payload.wallet) ? payload.wallet : null;
+
+  return {
+    id: String(payload.id),
+    email: readString(payload.email) ?? "",
+    username: readString(payload.username) ?? String(payload.id),
+    firstName: readString(payload.firstName),
+    lastName: readString(payload.lastName),
+    type: toUserType(payload.type),
+    wallet:
+      wallet && typeof wallet.publicKey === "string"
+        ? { publicKey: wallet.publicKey, type: readString(wallet.type) ?? "EXTERNAL" }
+        : undefined,
+  };
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat: hybrid login UI — wallet tab + email/password tab

## 🛠️ Issue

- Closes #325

## 📚 Description

> ⚠️ **Stacked on #338** (`feat/wallet-signin-flow`). Until that merges, GitHub shows its 3 commits here too. **Review only the last commit,** `feat(auth): split the login page into email and wallet tabs`. Merge #338 first; this branch retargets cleanly afterwards.

The login page now offers both auth methods behind a tablist: the pre-existing email flow and wallet sign-in.

**Email is the default tab.** Every existing account uses it, and the wallet path is additive rather than a replacement — a returning user sees exactly what they saw before, with one extra tab available.

### Why it had to be stacked on #338

`main` has none of the three pieces this issue's ACs require:

| AC | Provided by #338 |
|---|---|
| "Wallet tab: shows `WalletConnectModal` trigger + **sign-in flow**" | `WalletSignInButton`, `useWalletAuth`, `wallet-auth.service` |
| "After wallet login: redirect to dashboard **same as email login**" | `goToDashboard()`, extracted there for exactly this |

Both issues also restructure the same file. Branching from `main` would have meant rebuilding the service, hook and button from scratch, then resolving a hard conflict on `login/page.tsx` when both landed.

### Details worth a reviewer's eye

**Both panels stay mounted**, toggled with the `hidden` attribute rather than unmounted. Switching tabs mid-flow therefore does not discard typed credentials, nor an in-flight wallet signature — unmounting would abort the pending request in `useWalletAuth` and burn the nonce.

**The email panel is untouched inside.** Social buttons, divider and form are the same nodes in the same order; only their wrapper changed. That is what "no regression on existing email/password login" has to mean in practice.

**Keyboard behaviour follows the tablist pattern.** Arrow keys move between tabs and only the selected tab is in the Tab order. Without that, the second tab would be unreachable by keyboard — a `tabIndex={-1}` tab with no arrow handling is a trap, not a widget.

**Visual treatment reuses the tablist already in `search/page.tsx`** — same inset neumorphic track, same `bg-primary` active pill — rather than inventing a second tab style for the same design system.

## ✅ Changes applied

One commit on top of #338:

| File | Change |
|---|---|
| `src/app/login/page.tsx` | `AUTH_TABS` + `activeTab` state, tablist with arrow-key handling, two `role="tabpanel"` regions; wallet button moved out of the social row into its own panel |

No new components, no new dependencies, no change to the auth logic itself.

## 🔍 Evidence/Media (screenshots/videos)


https://github.com/user-attachments/assets/5b3862ae-20e5-44ba-b6d2-a78135f31001



**Gates:**

```
$ npx tsc --noEmit    exit 0
$ npm run build       exit 0
$ npx eslint .        ✖ 91 problems (86 errors, 5 warnings)
```

The 91 are **identical to the baseline** — zero new. `login/page.tsx` fails `prettier --check`, but it already failed at `HEAD` before this change (verified with `git show HEAD:… | prettier --check`); 305 files fail repo-wide, so reformatting would only add diff noise.

### Not covered

- **No test suite exists in this repo** — no vitest or jest config, no test script. The rendered-markup checks above plus `npm run build` are the strongest gates available.
- **Tab switching was verified in the served HTML, not by clicking.** The initial state, both panels, and the ARIA wiring are confirmed; the click and arrow-key interactions need a human at a browser.
- **The wallet tab's end-to-end flow depends on OFFER-HUB-API#143** (SEP-53 signature verification), which is merged. Worth confirming a real Freighter login through this tab before the D1.2 demo.
