### PR TITLE
feat: 'Claim Your Wallet' UI — custodial migration flow

### DIFF
--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/cn";
 import { MOCK_API_DELAY } from "@/lib/constants";
 import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
 import { NEUMORPHIC_CARD, PRIMARY_BUTTON, DANGER_BUTTON } from "@/lib/styles";
+import { ClaimWalletCard } from "@/components/settings/ClaimWalletCard";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 
 interface NotificationSettings {
@@ -367,6 +368,10 @@ export default function SettingsPage(): React.JSX.Element {
           </Link>
         </div>
       </div>
+
+      {/* Custodial → non-custodial migration. Sits above the account section
+          because it is a one-way change to who holds the keys, not a preference. */}
+      <ClaimWalletCard />
 
       <div className={cn(NEUMORPHIC_CARD, "border border-error/20")}>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,6 +9,7 @@ import {
   AuthInput,
   AuthDivider,
 } from "@/components/auth";
+import { WalletSignInButton } from "@/components/auth/WalletSignInButton";
 import { cn } from "@/lib/cn";
 import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
@@ -67,6 +68,17 @@ function LoginContent() {
     }
   };
 
+  /**
+   * Where a successful sign-in lands, whatever proved the identity.
+   * Shared so wallet auth cannot drift from the email path.
+   */
+  const goToDashboard = () => {
+    const defaultDashboard =
+      mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
+
+    router.push(redirectPath || defaultDashboard);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -106,10 +118,7 @@ function LoginContent() {
 
       setIsLoading(false);
 
-      const defaultDashboard =
-        mode === "client" ? "/app/client/dashboard" : "/app/freelancer/dashboard";
-
-      router.push(redirectPath || defaultDashboard);
+      goToDashboard();
     } catch (error) {
       console.error("Login error:", error);
       setErrors({ email: "Connection error. Please try again." });
@@ -152,6 +161,11 @@ function LoginContent() {
       {/* Social Auth */}
       <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}>
         <SocialAuthButtons />
+      </div>
+
+      {/* Wallet Auth — D1.2 challenge-response, same session as an email login */}
+      <div className="mt-3 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.12s", animationFillMode: "forwards" }}>
+        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Divider */}

--- a/src/components/auth/WalletSignInButton.tsx
+++ b/src/components/auth/WalletSignInButton.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { StellarIcon } from "@/components/ui/StellarIcon";
+import { LoadingSpinner } from "@/components/ui/Icon";
+import { WalletConnectModal } from "@/components/wallet/WalletConnectModal";
+import { useWalletKit } from "@/hooks/use-wallet-kit";
+import { useWalletAuth, type WalletAuthStep } from "@/hooks/useWalletAuth";
+
+export interface WalletSignInButtonProps {
+  /** Called once the wallet session is stored, so the page can redirect. */
+  onSignedIn?: () => void;
+  /** Mirrors the other auth buttons while an email login is in flight. */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * What the user is actually waiting on.
+ *
+ * The signing step blocks on the wallet's own confirmation popup, which is
+ * easily missed behind the browser window — naming it is the difference between
+ * waiting and knowing to go look.
+ */
+const STEP_LABEL: Record<Exclude<WalletAuthStep, "idle">, string> = {
+  "requesting-challenge": "Preparing sign-in...",
+  signing: "Check your wallet to sign",
+  verifying: "Verifying signature...",
+};
+
+/**
+ * Sign in with a Stellar wallet — the D1.2 challenge-response flow.
+ *
+ * With no wallet connected the click opens `WalletConnectModal` and the flow
+ * continues from its `onConnected`, so connecting and signing in read as one
+ * action rather than two.
+ */
+export function WalletSignInButton({
+  onSignedIn,
+  disabled = false,
+  className,
+}: WalletSignInButtonProps): React.JSX.Element {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { address } = useWalletKit();
+  const { signIn, step, isAuthenticating, error, reset } = useWalletAuth();
+
+  async function runSignIn(publicKey: string): Promise<void> {
+    const session = await signIn(publicKey);
+    if (session !== null) {
+      onSignedIn?.();
+    }
+  }
+
+  async function handleClick(): Promise<void> {
+    reset();
+
+    if (address === null) {
+      setIsModalOpen(true);
+      return;
+    }
+
+    await runSignIn(address);
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || isAuthenticating}
+        aria-busy={isAuthenticating}
+        className={cn(
+          "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl",
+          "bg-white border border-border-light cursor-pointer",
+          "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
+          "hover:shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff] hover:scale-[1.02]",
+          "active:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff] active:scale-[0.98]",
+          "transition-all duration-200",
+          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+        )}
+      >
+        {isAuthenticating ? (
+          <LoadingSpinner size="sm" />
+        ) : (
+          <span className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+            <StellarIcon className="text-primary" />
+          </span>
+        )}
+        <span className="text-sm font-medium text-text-primary">
+          {step === "idle" ? "Continue with wallet" : STEP_LABEL[step]}
+        </span>
+      </button>
+
+      {/* Announced rather than only shown: the failure often happens while the
+          user is looking at the wallet popup, not at this page. */}
+      {error !== null && (
+        <p role="alert" className="text-xs text-error px-1">
+          {error}
+        </p>
+      )}
+
+      <WalletConnectModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConnected={(connected) => {
+          setIsModalOpen(false);
+          void runSignIn(connected);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/ClaimWalletCard.tsx
+++ b/src/components/settings/ClaimWalletCard.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS, LoadingSpinner } from "@/components/ui/Icon";
+import { NEUMORPHIC_CARD, NEUMORPHIC_INSET, PRIMARY_BUTTON } from "@/lib/styles";
+import { WalletAddress } from "@/components/ui/WalletAddress";
+import { WalletConnectModal } from "@/components/wallet/WalletConnectModal";
+import { useWalletKit } from "@/hooks/use-wallet-kit";
+import { useAuthStore } from "@/stores/auth-store";
+import { requestChallenge } from "@/services/wallet-auth.service";
+import {
+  claimWallet,
+  ClaimWalletError,
+  type BlockingEscrow,
+  type ClaimWalletResult,
+} from "@/lib/api/wallet-claim";
+
+/** What the user is waiting on, so the button can say so. */
+type ClaimStep = "idle" | "requesting-challenge" | "signing" | "claiming";
+
+const STEP_LABEL: Record<Exclude<ClaimStep, "idle">, string> = {
+  "requesting-challenge": "Preparing...",
+  signing: "Check your wallet to sign",
+  claiming: "Transferring authority...",
+};
+
+function StepHeading({ n, title }: { n: number; title: string }): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-2.5 mb-1.5">
+      <span
+        className={cn(
+          "w-6 h-6 rounded-lg shrink-0 flex items-center justify-center",
+          "bg-primary/10 text-primary text-xs font-bold"
+        )}
+      >
+        {n}
+      </span>
+      <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+    </div>
+  );
+}
+
+/**
+ * Blocking escrows, named rather than counted.
+ *
+ * "You have 2 active escrows" leaves the user hunting; the order ids let them
+ * go straight to what has to finish first.
+ */
+function EscrowBlocker({ escrows }: { escrows: BlockingEscrow[] }): React.JSX.Element {
+  return (
+    <div role="alert" className="rounded-2xl border border-warning/30 bg-warning/10 p-4">
+      <div className="flex items-start gap-2.5">
+        <Icon path={ICON_PATHS.alertTriangle} size="md" className="text-warning shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-text-primary">
+            Finish your active escrows first
+          </p>
+          <p className="mt-1 text-sm text-text-secondary">
+            The platform still signs releases and refunds with the custodial key. Moving that
+            authority now would leave these funds stuck, so the migration stays closed until they
+            settle.
+          </p>
+
+          {escrows.length > 0 && (
+            <ul className="mt-3 space-y-1.5">
+              {escrows.map((escrow) => (
+                <li
+                  key={escrow.escrowId}
+                  className="flex items-center justify-between gap-3 text-xs"
+                >
+                  <span className="font-mono text-text-secondary truncate">{escrow.orderId}</span>
+                  <span className="shrink-0 rounded-md bg-background px-2 py-0.5 font-medium text-text-secondary">
+                    {escrow.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SuccessState({ result }: { result: ClaimWalletResult }): React.JSX.Element {
+  return (
+    <div className="rounded-2xl border border-success/30 bg-success/10 p-4">
+      <div className="flex items-start gap-2.5">
+        <Icon path={ICON_PATHS.check} size="md" className="text-success shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-text-primary">
+            Your wallet is now non-custodial
+          </p>
+          <p className="mt-1 text-sm text-text-secondary">
+            Signing authority belongs to your key. The account and its balances are unchanged —
+            nothing moved on-chain except who is allowed to sign.
+          </p>
+
+          <div className="mt-3">
+            <WalletAddress address={result.newSignerPublicKey} showFull />
+          </div>
+
+          {result.transactionHash !== null && (
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${result.transactionHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary-hover"
+            >
+              View the transaction
+              <Icon path={ICON_PATHS.externalLink} size="sm" />
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Claim Your Wallet" — hands a server-held wallet over to its owner.
+ *
+ * The three steps the migration plan promises: explain, connect, sign. The
+ * explanation is not decoration — this is irreversible, and the user is being
+ * asked to take custody of funds the platform held for them.
+ */
+export function ClaimWalletCard(): React.JSX.Element {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [step, setStep] = useState<ClaimStep>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [blockingEscrows, setBlockingEscrows] = useState<BlockingEscrow[] | null>(null);
+  const [result, setResult] = useState<ClaimWalletResult | null>(null);
+
+  const { address } = useWalletKit();
+  const token = useAuthStore((state) => state.token);
+
+  const isBusy = step !== "idle";
+
+  async function handleClaim(): Promise<void> {
+    if (address === null || token === null) return;
+
+    setError(null);
+    setBlockingEscrows(null);
+
+    try {
+      setStep("requesting-challenge");
+      const { challenge } = await requestChallenge(address);
+
+      setStep("signing");
+      const { signedMessage } = await StellarWalletsKit.signMessage(challenge, {
+        address,
+      });
+
+      setStep("claiming");
+      const claimed = await claimWallet(token, {
+        newSignerPublicKey: address,
+        signature: signedMessage,
+        challenge,
+      });
+
+      setResult(claimed);
+    } catch (cause) {
+      if (cause instanceof ClaimWalletError) {
+        if (cause.code === "WALLET_CLAIM_BLOCKED_BY_ESCROW") {
+          setBlockingEscrows(cause.activeEscrows);
+        } else {
+          setError(cause.message);
+        }
+      } else if (typeof cause === "object" && cause !== null && "message" in cause) {
+        // Wallet kits reject with plain objects; a declined signature lands here.
+        const { message } = cause as { message: unknown };
+        setError(typeof message === "string" ? message : "The signature was not completed.");
+      } else {
+        setError("Could not complete the migration. Please try again.");
+      }
+    } finally {
+      setStep("idle");
+    }
+  }
+
+  return (
+    <div className={NEUMORPHIC_CARD}>
+      <h2 className="text-lg font-semibold text-text-primary mb-1 flex items-center gap-2">
+        <Icon path={ICON_PATHS.shield} size="md" className="text-primary" />
+        Claim Your Wallet
+      </h2>
+      <p className="text-sm text-text-secondary mb-5">
+        Take full control of the wallet OfferHub currently holds for you.
+      </p>
+
+      {result !== null ? (
+        <SuccessState result={result} />
+      ) : (
+        <div className="space-y-4">
+          {/* Step 1 — what this actually does */}
+          <div className={cn(NEUMORPHIC_INSET, "rounded-2xl p-4")}>
+            <StepHeading n={1} title="What this does" />
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Right now OfferHub holds the key to your wallet. This transfers signing authority to a
+              wallet you control, so only you can move the funds.
+            </p>
+            <ul className="mt-3 space-y-1.5 text-sm text-text-secondary">
+              <li className="flex gap-2">
+                <Icon path={ICON_PATHS.check} size="sm" className="text-success shrink-0 mt-0.5" />
+                Your balances and account stay exactly as they are — no funds move.
+              </li>
+              <li className="flex gap-2">
+                <Icon path={ICON_PATHS.check} size="sm" className="text-success shrink-0 mt-0.5" />
+                OfferHub can no longer sign on your behalf afterwards.
+              </li>
+              <li className="flex gap-2">
+                <Icon
+                  path={ICON_PATHS.alertTriangle}
+                  size="sm"
+                  className="text-warning shrink-0 mt-0.5"
+                />
+                This cannot be undone. Keep your wallet&apos;s recovery phrase safe.
+              </li>
+            </ul>
+          </div>
+
+          {/* Step 2 — connect */}
+          <div className={cn(NEUMORPHIC_INSET, "rounded-2xl p-4")}>
+            <StepHeading n={2} title="Connect the wallet you want to own it" />
+            {address === null ? (
+              <>
+                <p className="text-sm text-text-secondary mb-3">
+                  Choose the Stellar wallet that will hold the signing key from now on.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(true)}
+                  className={cn(PRIMARY_BUTTON, "w-full sm:w-auto")}
+                >
+                  Connect wallet
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-text-secondary mb-3">
+                  Authority will be transferred to this key:
+                </p>
+                <WalletAddress address={address} showFull />
+              </>
+            )}
+          </div>
+
+          {/* Step 3 — sign */}
+          <div className={cn(NEUMORPHIC_INSET, "rounded-2xl p-4")}>
+            <StepHeading n={3} title="Sign to confirm" />
+            <p className="text-sm text-text-secondary mb-3">
+              Approve a one-time signature proving the wallet is yours. OfferHub then submits the
+              transfer to Stellar.
+            </p>
+            <button
+              type="button"
+              onClick={handleClaim}
+              disabled={address === null || token === null || isBusy}
+              aria-busy={isBusy}
+              className={cn(PRIMARY_BUTTON, "w-full flex items-center justify-center gap-2")}
+            >
+              {isBusy && <LoadingSpinner size="sm" />}
+              {step === "idle" ? "Sign and transfer authority" : STEP_LABEL[step]}
+            </button>
+          </div>
+
+          {blockingEscrows !== null && <EscrowBlocker escrows={blockingEscrows} />}
+
+          {error !== null && (
+            <p role="alert" className="text-sm text-error px-1">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+
+      <WalletConnectModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+    </div>
+  );
+}

--- a/src/hooks/useWalletAuth.ts
+++ b/src/hooks/useWalletAuth.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  requestChallenge,
+  verifySignature,
+  WalletAuthError,
+  type WalletSession,
+} from "@/services/wallet-auth.service";
+
+/**
+ * Where the flow currently is. Each value maps to a distinct thing the user is
+ * waiting on, so the UI can say "check your wallet" instead of a generic spinner
+ * — the signing step is the one that blocks on a browser extension popup and is
+ * by far the slowest.
+ */
+export type WalletAuthStep = "idle" | "requesting-challenge" | "signing" | "verifying";
+
+export interface UseWalletAuthResult {
+  /** Run challenge → sign → verify → store. Resolves to the session, or null on failure. */
+  signIn: (publicKey: string) => Promise<WalletSession | null>;
+  step: WalletAuthStep;
+  isAuthenticating: boolean;
+  error: string | null;
+  /** Clear a previous failure, e.g. when the user reopens the dialog. */
+  reset: () => void;
+}
+
+/**
+ * Message shown for a given failure.
+ *
+ * The API's own message is used when it is safe and specific; the cases below
+ * are the ones where it is either too terse or describes a server-side concept
+ * the user has no way to act on.
+ */
+function toUserMessage(error: unknown): string {
+  if (error instanceof WalletAuthError) {
+    switch (error.code) {
+      case "WALLET_CHALLENGE_EXPIRED":
+        return "The sign-in request expired. Please try again.";
+      case "WALLET_CHALLENGE_MISMATCH":
+      case "INVALID_SIGNATURE_FORMAT":
+        return "That signature could not be verified. Please try signing again.";
+      case "NETWORK_ERROR":
+      case "MALFORMED_RESPONSE":
+        return error.message;
+      default:
+        return error.message;
+    }
+  }
+
+  // Wallet kits reject with plain objects as often as with Errors, and a user
+  // declining the signature prompt lands here.
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const { message } = error as { message: unknown };
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+
+  return "Could not sign in with your wallet. Please try again.";
+}
+
+/**
+ * Wallet sign-in: request a nonce, sign it with the connected wallet, exchange
+ * the signature for a JWT, and store the session exactly as an email login does.
+ */
+export function useWalletAuth(): UseWalletAuthResult {
+  const [step, setStep] = useState<WalletAuthStep>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const login = useAuthStore((state) => state.login);
+  const connectWallet = useAuthStore((state) => state.connectWallet);
+
+  // Guards against a double-submit racing itself: two flows would each burn a
+  // nonce, and the loser's signature would verify against an already-consumed
+  // challenge.
+  const inFlight = useRef(false);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setStep("idle");
+  }, []);
+
+  const signIn = useCallback(
+    async (publicKey: string): Promise<WalletSession | null> => {
+      if (inFlight.current) {
+        return null;
+      }
+
+      inFlight.current = true;
+      setError(null);
+
+      try {
+        setStep("requesting-challenge");
+        const { challenge } = await requestChallenge(publicKey);
+
+        setStep("signing");
+        // Blocks on the wallet's own confirmation UI. `address` pins the request
+        // to the key we asked a challenge for, in case the wallet holds several.
+        const { signedMessage } = await StellarWalletsKit.signMessage(challenge, {
+          address: publicKey,
+        });
+
+        setStep("verifying");
+        const session = await verifySignature(publicKey, signedMessage, challenge);
+
+        // Same store transition as an email login, plus the wallet slice so the
+        // navbar and balance card see the address without re-reading the kit.
+        login(session.user, session.token);
+        connectWallet(publicKey);
+
+        setStep("idle");
+        return session;
+      } catch (cause) {
+        setError(toUserMessage(cause));
+        setStep("idle");
+        return null;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [login, connectWallet]
+  );
+
+  return {
+    signIn,
+    step,
+    isAuthenticating: step !== "idle",
+    error,
+    reset,
+  };
+}

--- a/src/lib/api/wallet-claim.ts
+++ b/src/lib/api/wallet-claim.ts
@@ -1,0 +1,174 @@
+/**
+ * "Claim Your Wallet" — the custodial → non-custodial migration.
+ *
+ * `POST /wallet/claim` hands the signing authority of a server-held account to
+ * a key the user controls, via a Stellar `set_options` transaction. No funds
+ * move and the account ID does not change; only who may sign.
+ */
+
+import { API_URL } from "@/config/api";
+
+/** An escrow that still holds, or may still move, the caller's funds. */
+export interface BlockingEscrow {
+  escrowId: string;
+  orderId: string;
+  status: string;
+}
+
+/** A wallet on the account after the migration. */
+export interface ClaimedWallet {
+  id: string;
+  publicKey: string;
+  type: string;
+  isPrimary: boolean;
+  isActive: boolean;
+}
+
+export interface ClaimWalletResult {
+  /** The custodial key that has just been stripped of its authority. */
+  custodialPublicKey: string;
+  /** The key that now controls the account. */
+  newSignerPublicKey: string;
+  /** Null when the rotation was already on-chain and only the database caught up. */
+  transactionHash: string | null;
+  wallets: ClaimedWallet[];
+}
+
+/**
+ * A refused claim, carrying the API's error code so the UI can respond to each
+ * reason differently — an active escrow is a "come back later", a non-claimable
+ * account is a "there is nothing to do here".
+ */
+export class ClaimWalletError extends Error {
+  readonly code: string;
+  readonly status: number;
+  /** Present only for `WALLET_CLAIM_BLOCKED_BY_ESCROW`. */
+  readonly activeEscrows: BlockingEscrow[];
+
+  constructor(message: string, code: string, status: number, activeEscrows: BlockingEscrow[] = []) {
+    super(message);
+    this.name = "ClaimWalletError";
+    this.code = code;
+    this.status = status;
+    this.activeEscrows = activeEscrows;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/** Narrow `error.details.activeEscrows`, dropping anything malformed. */
+function readBlockingEscrows(details: unknown): BlockingEscrow[] {
+  if (!isRecord(details) || !Array.isArray(details.activeEscrows)) {
+    return [];
+  }
+
+  return details.activeEscrows.flatMap((entry): BlockingEscrow[] => {
+    if (!isRecord(entry)) return [];
+
+    const escrowId = readString(entry.escrowId);
+    const orderId = readString(entry.orderId);
+    const status = readString(entry.status);
+
+    return escrowId && orderId && status ? [{ escrowId, orderId, status }] : [];
+  });
+}
+
+async function toClaimError(response: Response): Promise<ClaimWalletError> {
+  let code = "UNKNOWN_ERROR";
+  let message = `Request failed with status ${response.status}.`;
+  let escrows: BlockingEscrow[] = [];
+
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && isRecord(payload.error)) {
+      code = readString(payload.error.code) ?? code;
+      message = readString(payload.error.message) ?? message;
+      escrows = readBlockingEscrows(payload.error.details);
+    }
+  } catch {
+    // Not JSON; the status-based defaults stand.
+  }
+
+  return new ClaimWalletError(message, code, response.status, escrows);
+}
+
+/**
+ * Transfer signing authority of the caller's custodial wallet to
+ * `newSignerPublicKey`.
+ *
+ * The signature proves the caller controls the destination key. It covers a
+ * nonce from `POST /auth/wallet/challenge`, which the server consumes on
+ * success — a retry needs a fresh one.
+ *
+ * @throws {ClaimWalletError} for every refusal, with the API's code attached.
+ */
+export async function claimWallet(
+  token: string,
+  input: { newSignerPublicKey: string; signature: string; challenge: string }
+): Promise<ClaimWalletResult> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_URL}/wallet/claim`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(input),
+    });
+  } catch {
+    throw new ClaimWalletError(
+      "Could not reach the server. Check your connection and try again.",
+      "NETWORK_ERROR",
+      0
+    );
+  }
+
+  if (!response.ok) {
+    throw await toClaimError(response);
+  }
+
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || !isRecord(payload.data)) {
+    throw new ClaimWalletError(
+      "The server returned an unexpected response.",
+      "MALFORMED_RESPONSE",
+      response.status
+    );
+  }
+
+  const data = payload.data;
+
+  return {
+    custodialPublicKey: readString(data.custodialPublicKey) ?? "",
+    newSignerPublicKey: readString(data.newSignerPublicKey) ?? "",
+    transactionHash: readString(data.transactionHash),
+    wallets: Array.isArray(data.wallets)
+      ? data.wallets.flatMap((w): ClaimedWallet[] => {
+          if (!isRecord(w)) return [];
+          const id = readString(w.id);
+          const publicKey = readString(w.publicKey);
+          const type = readString(w.type);
+          return id && publicKey && type
+            ? [
+                {
+                  id,
+                  publicKey,
+                  type,
+                  isPrimary: w.isPrimary === true,
+                  isActive: w.isActive === true,
+                },
+              ]
+            : [];
+        })
+      : [],
+  };
+}

--- a/src/services/wallet-auth.service.ts
+++ b/src/services/wallet-auth.service.ts
@@ -1,0 +1,185 @@
+/**
+ * Wallet Authentication Service
+ *
+ * Client half of the D1.2 challenge-response flow: ask the API for a nonce,
+ * sign it in the user's wallet, hand the signature back for a JWT.
+ *
+ * Uses `fetch` directly rather than `./http-client`, which types every response
+ * as `ApiResponse` (`ok`, `code`, `title`, …). This API answers with the
+ * `{ data }` / `{ error }` envelope instead, so `ApiResponse.ok` would read as
+ * `undefined` and a successful call would look like a failure. The `lib/api/*`
+ * modules talk to the same backend the same way.
+ */
+
+import { API_URL } from "@/config/api";
+import type { User } from "@/stores/auth-store";
+
+/** A nonce to sign, and how long the API will keep accepting it. */
+export interface WalletChallenge {
+  challenge: string;
+  expiresIn: number;
+}
+
+/** A verified wallet session: the same pair an email login produces. */
+export interface WalletSession {
+  user: User;
+  token: string;
+}
+
+/**
+ * A failed wallet-auth call, carrying the API's own error code so callers can
+ * react to specific cases (an expired nonce is worth retrying; a mismatched
+ * signature is not).
+ */
+export class WalletAuthError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = "WalletAuthError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Pull the API's `{ error: { code, message } }` out of a failed response.
+ *
+ * Falls back to the HTTP status when the body is missing or unparseable — a 502
+ * from a proxy never reaches the application error envelope.
+ */
+async function toWalletAuthError(response: Response): Promise<WalletAuthError> {
+  let code = "UNKNOWN_ERROR";
+  let message = `Request failed with status ${response.status}.`;
+
+  try {
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && isRecord(payload.error)) {
+      code = readString(payload.error.code) ?? code;
+      message = readString(payload.error.message) ?? message;
+    }
+  } catch {
+    // Body was not JSON; the status-based defaults above stand.
+  }
+
+  return new WalletAuthError(message, code, response.status);
+}
+
+async function postJson(path: string, body: unknown): Promise<unknown> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_URL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw new WalletAuthError(
+      "Could not reach the server. Check your connection and try again.",
+      "NETWORK_ERROR",
+      0
+    );
+  }
+
+  if (!response.ok) {
+    throw await toWalletAuthError(response);
+  }
+
+  const payload: unknown = await response.json();
+  if (!isRecord(payload) || payload.data === undefined) {
+    throw new WalletAuthError(
+      "The server returned an unexpected response.",
+      "MALFORMED_RESPONSE",
+      response.status
+    );
+  }
+
+  return payload.data;
+}
+
+/**
+ * Ask the API for a nonce bound to `publicKey`.
+ *
+ * Public endpoint — ownership has not been proven yet, which is what the
+ * signature in {@link verifySignature} is for.
+ */
+export async function requestChallenge(publicKey: string): Promise<WalletChallenge> {
+  const data = await postJson("/auth/wallet/challenge", { publicKey });
+
+  if (!isRecord(data) || typeof data.challenge !== "string") {
+    throw new WalletAuthError(
+      "The server did not return a challenge to sign.",
+      "MALFORMED_RESPONSE",
+      200
+    );
+  }
+
+  return {
+    challenge: data.challenge,
+    expiresIn: typeof data.expiresIn === "number" ? data.expiresIn : 0,
+  };
+}
+
+/**
+ * Exchange a signed challenge for a session.
+ *
+ * `challenge` is a parameter rather than state held here because the API
+ * verifies the signature against the exact nonce it issued, and the nonce is
+ * consumed on success — a second attempt needs a fresh one from
+ * {@link requestChallenge}.
+ */
+export async function verifySignature(
+  publicKey: string,
+  signature: string,
+  challenge: string
+): Promise<WalletSession> {
+  const data = await postJson("/auth/wallet/verify", { publicKey, signature, challenge });
+
+  if (!isRecord(data) || typeof data.token !== "string" || !isRecord(data.user)) {
+    throw new WalletAuthError("The server did not return a session.", "MALFORMED_RESPONSE", 200);
+  }
+
+  return { user: toUser(data.user), token: data.token };
+}
+
+const USER_TYPES = ["BUYER", "SELLER", "BOTH", "ADMIN"] as const;
+type UserType = (typeof USER_TYPES)[number];
+
+function toUserType(value: unknown): UserType | undefined {
+  return USER_TYPES.find((candidate) => candidate === value);
+}
+
+/**
+ * Narrow the API's user payload onto the store's `User`.
+ *
+ * `email` is nullable server-side (a wallet-first account may never have one)
+ * but required by the store, so it collapses to an empty string rather than
+ * being dropped — the store's consumers render it, they do not authenticate
+ * with it.
+ */
+function toUser(payload: Record<string, unknown>): User {
+  const wallet = isRecord(payload.wallet) ? payload.wallet : null;
+
+  return {
+    id: String(payload.id),
+    email: readString(payload.email) ?? "",
+    username: readString(payload.username) ?? String(payload.id),
+    firstName: readString(payload.firstName),
+    lastName: readString(payload.lastName),
+    type: toUserType(payload.type),
+    wallet:
+      wallet && typeof wallet.publicKey === "string"
+        ? { publicKey: wallet.publicKey, type: readString(wallet.type) ?? "EXTERNAL" }
+        : undefined,
+  };
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat: 'Claim Your Wallet' UI — custodial migration flow

## 🛠️ Issue

- Closes #326

## 📚 Description

> ⚠️ **Stacked on #338** (`feat/wallet-signin-flow`). Until that merges, GitHub shows its 3 commits here too. **Review only the last two commits,** `feat(api): add the wallet claim client` and `feat(settings): add the 'Claim Your Wallet' migration flow`. Merge #338 first; this branch retargets cleanly afterwards.

UI for the 103 existing custodial users to take ownership of their wallet — the flow SCF committed to in Revision 3.

Lives in **`/app/settings`**, above the account section. This is a one-way change to who holds the keys, not a preference.

### Why it is stacked on #338 rather than branched from main

`POST /wallet/claim` requires a signature over a nonce from `POST /auth/wallet/challenge`. `requestChallenge()` lives in `wallet-auth.service.ts`, which is on #338's branch and not yet on `main`. Branching from main would have meant duplicating it.

It is stacked on **#338 specifically, not #339** — #339 only restructures the login page, which this never touches. Two levels instead of three.

No file overlap with either: they touch `login/page.tsx` and the auth components; this touches `settings/page.tsx` and adds new files.

### The three steps

**Step 1 — what this does.** Not decoration. The transfer is irreversible and the user is being asked to take custody of funds the platform has been holding, so the copy states plainly that balances do not move, that OfferHub can no longer sign afterwards, and that the wallet's recovery phrase is now their responsibility.

**Step 2 — connect the wallet that will own it.** Reuses the existing `WalletConnectModal`. Once connected, the destination key is shown in full via `WalletAddress` — the user should see exactly which key is about to receive authority.

**Step 3 — sign to confirm.** Requests a nonce, signs it through the kit, and calls the API. Each phase names what is being waited on rather than showing an anonymous spinner; *"Check your wallet to sign"* matters because that popup is easily missed behind the browser window.

### Active escrows block the migration, by name

The API refuses with `WALLET_CLAIM_BLOCKED_BY_ESCROW` and returns the offending escrows in `error.details.activeEscrows`. The UI lists them with order id and status.

"You have 2 active escrows" leaves the user hunting; the order ids send them straight to what has to finish. The warning also explains *why* it is blocked — the platform still signs releases and refunds with the custodial key, so rotating it mid-flight would strand those funds.

The other two refusals are handled distinctly: `WALLET_NOT_CLAIMABLE` (nothing to claim — either wallet-first or already migrated) and `WALLET_CLAIM_SIGNER_INVALID` (claiming toward the custodial key itself).

### Success state

Confirms the wallet is non-custodial, shows the key that now controls it, and links the `set_options` transaction on the explorer when there is one. `transactionHash` is `null` when the rotation was already on-chain and only the database needed reconciling — that is a real API response, not an error, so the link is conditional.

## ✅ Changes applied

Two commits on top of #338:

| Commit | Change |
|---|---|
| `feat(api)` | `lib/api/wallet-claim.ts` — typed client, `ClaimWalletError` carrying the API's code and the blocking escrows |
| `feat(settings)` | `ClaimWalletCard` + wiring into the settings page |

Errors are narrowed rather than flattened to a string, because three distinct refusals call for three distinct UI responses. All API payloads are narrowed with type guards — no casts, no `any`. No new dependencies.

## 🔍 Evidence/Media (screenshots/videos)


https://github.com/user-attachments/assets/e59e05ab-7f58-402a-ae21-81ebaac9a5ec



The 91 are **identical to the baseline** — zero new. Both new files are Prettier-clean; no existing file was reformatted.

**Server side is already merged and verified.** `POST /wallet/claim` landed in OFFER-HUB-API#139, and its `set_options` rotation was confirmed against a real testnet ledger: master weight → 0, new signer → 1, thresholds 1/1/1, balance delta exactly the network fee, and the retired master key rejected with `tx_bad_auth`. Signature verification goes through SEP-53 as of OFFER-HUB-API#143.

### Not covered

- **No test suite exists in this repo** — no vitest or jest config, no test script. The rendered-markup check and `npm run build` are the strongest gates available.
- **The flow has not been driven end-to-end in a browser.** The static states render; the connect → sign → claim path needs a human with Freighter and an account that actually holds a custodial wallet.
- **The escrow-blocked and success states were not exercised against live data.** Both are rendered from real API response shapes, but reproducing them needs a seeded account — one with an unsettled escrow, one without.
- **The explorer link is hardcoded to testnet.** Correct for T1; it will need the network-aware base URL from `config/wallet.ts` before mainnet (T3, D3.2).
