### PR TITLE
feat: hybrid login UI — wallet tab + email/password tab

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,7 +10,9 @@ import {
   AuthDivider,
 } from "@/components/auth";
 import { WalletSignInButton } from "@/components/auth/WalletSignInButton";
+import { StellarIcon } from "@/components/ui/StellarIcon";
 import { cn } from "@/lib/cn";
+import { NEUMORPHIC_INSET } from "@/lib/styles";
 import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
 import type { LoginFormData, AuthFormErrors } from "@/types/auth.types";
@@ -231,12 +233,37 @@ function LoginContent() {
         id="auth-panel-wallet"
         aria-labelledby="auth-tab-wallet"
         hidden={activeTab !== "wallet"}
+        // Roughly the height of the email panel, so switching tabs does not
+        // collapse the card and shove the footer links up the page.
+        className="min-h-[22rem] flex flex-col justify-center"
       >
-        <p className="text-sm text-text-secondary text-center mb-3">
-          Connect a Stellar wallet and sign a one-time message to prove it is yours.
-          No password needed.
+        <div className={cn(NEUMORPHIC_INSET, "rounded-2xl p-6 text-center")}>
+          <span
+            className={cn(
+              "mx-auto mb-4 w-14 h-14 rounded-2xl flex items-center justify-center",
+              "bg-primary text-white",
+              "shadow-[4px_4px_8px_#d1d5db,-2px_-2px_6px_#ffffff]"
+            )}
+          >
+            <StellarIcon className="w-7 h-7" />
+          </span>
+
+          <h2 className="text-base font-semibold text-text-primary mb-1.5">
+            Sign in with your Stellar wallet
+          </h2>
+          <p className="text-sm text-text-secondary leading-relaxed">
+            Approve a one-time signature to prove the wallet is yours. No password,
+            and your keys never leave the wallet.
+          </p>
+        </div>
+
+        <div className="mt-4">
+          <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
+        </div>
+
+        <p className="text-xs text-text-secondary text-center mt-3">
+          Works with Freighter, Lobstr and xBull
         </p>
-        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Email panel — the pre-existing sign-in experience, unchanged */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -15,6 +15,13 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useModeStore } from "@/stores/mode-store";
 import type { LoginFormData, AuthFormErrors } from "@/types/auth.types";
 
+type AuthTabId = "email" | "wallet";
+
+const AUTH_TABS: ReadonlyArray<{ id: AuthTabId; label: string }> = [
+  { id: "email", label: "Email / Password" },
+  { id: "wallet", label: "Connect Wallet" },
+];
+
 function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -29,6 +36,26 @@ function LoginContent() {
   });
   const [errors, setErrors] = useState<AuthFormErrors>({});
   const [redirectPath, setRedirectPath] = useState<string | null>(null);
+  // Email stays the default: it is what every existing account uses, and the
+  // wallet path is additive rather than a replacement.
+  const [activeTab, setActiveTab] = useState<AuthTabId>("email");
+
+  /**
+   * Arrow keys move between tabs, as a tablist is expected to behave — only the
+   * selected tab is in the Tab order, so without this the second one would be
+   * unreachable by keyboard.
+   */
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+
+    e.preventDefault();
+    const current = AUTH_TABS.findIndex((t) => t.id === activeTab);
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = AUTH_TABS[(current + delta + AUTH_TABS.length) % AUTH_TABS.length];
+
+    setActiveTab(next.id);
+    document.getElementById(`auth-tab-${next.id}`)?.focus();
+  };
 
   useEffect(() => {
     if (searchParams.get("registered") === "true") {
@@ -158,14 +185,70 @@ function LoginContent() {
         </p>
       </div>
 
+      {/* Method tabs */}
+      <div
+        role="tablist"
+        aria-label="Sign-in method"
+        onKeyDown={handleTabKeyDown}
+        className={cn(
+          "flex gap-2 p-1 rounded-2xl bg-background mb-4",
+          "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+          "opacity-0 animate-fade-in-up"
+        )}
+        style={{ animationDelay: "0.08s", animationFillMode: "forwards" }}
+      >
+        {AUTH_TABS.map(({ id, label }) => {
+          const active = activeTab === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              id={`auth-tab-${id}`}
+              aria-selected={active}
+              aria-controls={`auth-panel-${id}`}
+              // Only the selected tab is reachable by Tab; the arrow keys move
+              // between them, which is how a tablist is meant to behave.
+              tabIndex={active ? 0 : -1}
+              onClick={() => setActiveTab(id)}
+              className={cn(
+                "flex-1 px-3 py-2.5 rounded-xl text-sm font-medium transition-all cursor-pointer",
+                "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
+                active
+                  ? "bg-primary text-white shadow-[2px_2px_6px_#d1d5db]"
+                  : "text-text-secondary hover:text-text-primary"
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Wallet panel */}
+      <div
+        role="tabpanel"
+        id="auth-panel-wallet"
+        aria-labelledby="auth-tab-wallet"
+        hidden={activeTab !== "wallet"}
+      >
+        <p className="text-sm text-text-secondary text-center mb-3">
+          Connect a Stellar wallet and sign a one-time message to prove it is yours.
+          No password needed.
+        </p>
+        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
+      </div>
+
+      {/* Email panel — the pre-existing sign-in experience, unchanged */}
+      <div
+        role="tabpanel"
+        id="auth-panel-email"
+        aria-labelledby="auth-tab-email"
+        hidden={activeTab !== "email"}
+      >
       {/* Social Auth */}
       <div className="opacity-0 animate-fade-in-up" style={{ animationDelay: "0.1s", animationFillMode: "forwards" }}>
         <SocialAuthButtons />
-      </div>
-
-      {/* Wallet Auth — D1.2 challenge-response, same session as an email login */}
-      <div className="mt-3 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.12s", animationFillMode: "forwards" }}>
-        <WalletSignInButton disabled={isLoading} onSignedIn={goToDashboard} />
       </div>
 
       {/* Divider */}
@@ -241,6 +324,7 @@ function LoginContent() {
           </button>
         </div>
       </form>
+      </div>
 
       {/* Register Link */}
       <p className="text-center text-sm text-text-secondary mt-4 opacity-0 animate-fade-in-up" style={{ animationDelay: "0.35s", animationFillMode: "forwards" }}>

--- a/src/components/auth/WalletSignInButton.tsx
+++ b/src/components/auth/WalletSignInButton.tsx
@@ -70,24 +70,27 @@ export function WalletSignInButton({
         onClick={handleClick}
         disabled={disabled || isAuthenticating}
         aria-busy={isAuthenticating}
+        // The primary action of its panel, so it mirrors the email tab's submit
+        // button rather than the secondary styling of the OAuth row.
         className={cn(
-          "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl",
-          "bg-white border border-border-light cursor-pointer",
-          "shadow-[3px_3px_6px_#d1d5db,-3px_-3px_6px_#ffffff]",
-          "hover:shadow-[5px_5px_10px_#d1d5db,-5px_-5px_10px_#ffffff] hover:scale-[1.02]",
-          "active:shadow-[inset_3px_3px_6px_#d1d5db,inset_-3px_-3px_6px_#ffffff] active:scale-[0.98]",
+          "w-full flex items-center justify-center gap-2.5 px-6 py-3 rounded-xl",
+          "bg-primary text-white font-medium cursor-pointer",
+          "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+          "hover:bg-primary-hover hover:shadow-[6px_6px_12px_#d1d5db,-6px_-6px_12px_#ffffff] hover:scale-[1.02]",
+          "active:shadow-[inset_4px_4px_8px_rgba(0,0,0,0.2)] active:scale-[0.98]",
+          "focus-visible:ring-2 focus-visible:ring-primary/40 outline-none",
           "transition-all duration-200",
-          "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          "disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:scale-100"
         )}
       >
         {isAuthenticating ? (
           <LoadingSpinner size="sm" />
         ) : (
-          <span className="w-5 h-5 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-            <StellarIcon className="text-primary" />
+          <span className="w-5 h-5 rounded-lg bg-white/20 flex items-center justify-center shrink-0">
+            <StellarIcon className="text-white" />
           </span>
         )}
-        <span className="text-sm font-medium text-text-primary">
+        <span className="text-sm">
           {step === "idle" ? "Continue with wallet" : STEP_LABEL[step]}
         </span>
       </button>


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:
- feat: hybrid login UI — wallet tab + email/password tab

## 🛠️ Issue
- Closes #325

## 📚 Description
Rebased version of #339 (from @KevinMB0220) after the base #338 was squash-merged. The stacked commits from #338 have been dropped; only the two new commits for this issue remain:

- `feat(auth): split the login page into email and wallet tabs`
- `style(auth): give the wallet tab its own weight`

Tablist with arrow-key keyboard navigation. Both panels stay mounted via `hidden` attribute (not unmounted) so switching tabs mid-flow does not abort an in-flight SWK signMessage or discard typed credentials. Email tab is default. Visual treatment reuses the `search/page.tsx` tablist pattern.

## ✅ Changes applied
- `src/app/login/page.tsx` — AUTH_TABS, activeTab state, tablist with arrow-key handling, two role="tabpanel" regions

## 🔍 Evidence/Media
See #339 for video evidence. Reviewed and approved there.