### PR TITLE
feat(labs): removable Sub Rosa sealed-proposals demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,14 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 #  public  -> GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN).
 # A value that is not a Stellar public key is ignored.
 # NEXT_PUBLIC_STELLAR_USDC_ISSUER=
+
+# ====================================
+# Sub Rosa demo (removable feature)
+# ====================================
+
+# Gates the isolated /labs/sub-rosa evaluation page. When unset or "false" the
+# route 404s. Sample data only — no dependency, no network call, no on-chain
+# activity. Delete this block together with src/features/sub-rosa and
+# src/app/labs to remove the feature entirely.
+# See src/features/sub-rosa/README.md
+NEXT_PUBLIC_SUBROSA_DEMO=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,31 @@ src/
 | Border radius (container) | `rounded-2xl` |
 | Border radius (interactive) | `rounded-xl` |
 
+#### Neumorphism is not optional
+
+**OFFER HUB is a neumorphic UI. Every surface you build must carry elevation — raised or sunken. A flat coloured block is a bug, not a style choice.**
+
+This is the most common way generated UI drifts off-brand: the colours come out right, but everything is painted flat and the page stops looking like the rest of the site. Before calling any frontend work done, look at every surface you added and decide which of these it is:
+
+| Surface | Treatment |
+|---------|-----------|
+| Cards, panels, banners | Raised — `bg-white` + `shadow-[var(--shadow-neumorphic-light)]` |
+| Wells, inputs, read-only fields | Sunken — `bg-background` + `shadow-[var(--shadow-neumorphic-inset-light)]` |
+| Badges, chips, pills, tabs, status tags | Sunken, tighter — `shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]` |
+| Active / selected item | Raised + `bg-primary text-white` — `shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]` |
+| Pressed state | Swap the raised shadow for the inset one |
+| Page background | The one legitimate flat surface — plain `bg-background` |
+
+Rules that follow from this:
+
+- **Never use a solid filled panel** (`bg-secondary`, `bg-primary`) as a large container. The raised/sunken shadow pair only reads against the light `#F1F3F7` background, so a filled block flattens the page. Use a raised white surface and put the colour in the text, the icon, or a small badge instead.
+- **Prefer the CSS variables** (`--shadow-neumorphic-light`, `--shadow-neumorphic-inset-light`) over hardcoded shadows — they are the ones that adapt to dark mode. Use the hardcoded 2px/4px variants only for small elements needing a tighter shadow, matching `AppSidebar.tsx`.
+- **Nest elevation deliberately**: raised chips inside a sunken well read as objects sitting in the recess. Never nest raised inside raised.
+- Reuse `Card` (`variant="neumorphic" | "neumorphic-inset"`) and `Button` from `/components/ui/` rather than rebuilding the shadows by hand.
+
 ### Key Rules
 
+- **Every surface carries elevation — raised or sunken. Never flat.** See the neumorphism section above
 - No `any` — TypeScript strict mode enforced
 - All components must handle loading, error, and empty states (see `docs/ui-states.md`)
 - No hardcoded strings — use constants from `/config/`

--- a/src/app/labs/layout.tsx
+++ b/src/app/labs/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+/**
+ * `/labs` holds isolated evaluation pages that are not part of the product.
+ * They must never be indexed — same posture as the authenticated app shell in
+ * `src/app/app/layout.tsx`.
+ */
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+interface LabsLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function LabsLayout({ children }: LabsLayoutProps): React.JSX.Element {
+  return <>{children}</>;
+}

--- a/src/app/labs/sub-rosa/page.tsx
+++ b/src/app/labs/sub-rosa/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { IS_SUBROSA_DEMO_ENABLED, SubRosaDemo } from "@/features/sub-rosa";
+
+export const metadata: Metadata = {
+  title: "Sub Rosa sealed proposals — demo",
+};
+
+/**
+ * Evaluation demo for Sub Rosa's optional sealed-proposal layer.
+ *
+ * Disabled unless NEXT_PUBLIC_SUBROSA_DEMO=true, in which case the route
+ * behaves as if it does not exist. See src/features/sub-rosa/README.md.
+ */
+export default function SubRosaDemoPage(): React.JSX.Element {
+  if (!IS_SUBROSA_DEMO_ENABLED) {
+    notFound();
+  }
+
+  return <SubRosaDemo />;
+}

--- a/src/features/sub-rosa/README.md
+++ b/src/features/sub-rosa/README.md
@@ -1,0 +1,86 @@
+# Sub Rosa — sealed proposals demo
+
+An **isolated, removable** evaluation page for [Sub Rosa](https://github.com/karagozemin/Sub-Rosa),
+a third-party protocol that offers an optional sealed-proposal layer for marketplaces: freelancers
+submit privately, everything is revealed together at a shared deadline, and only then does the
+client compare and pick.
+
+Route: **`/labs/sub-rosa`** (disabled by default).
+
+## How to enable it
+
+```bash
+# .env.local
+NEXT_PUBLIC_SUBROSA_DEMO=true
+```
+
+With the flag unset or `false`, the route calls `notFound()` and behaves as if it does not exist.
+
+## How to remove it
+
+```bash
+rm -rf src/features/sub-rosa src/app/labs
+```
+
+Then delete the `NEXT_PUBLIC_SUBROSA_DEMO` block from `.env.example`. That is the whole removal —
+there is no lockfile change to revert, no store or service to unwire, and no migration.
+
+## Why it is isolated rather than integrated
+
+This is an evaluation, not an adopted dependency. The reasons are concrete:
+
+| Concern | Evidence |
+| --- | --- |
+| No funds-handling audit | Sub Rosa's own [`docs/LIMITATIONS.md`](https://github.com/karagozemin/Sub-Rosa/blob/main/docs/LIMITATIONS.md): *"Core v2 … has no independent funds-handling audit yet"* |
+| Latest SDK is uninstallable with npm | `npm i @sub-rosa/sdk@0.2.2` fails with `EUNSUPPORTEDPROTOCOL` — it publishes `workspace:^` dependency specifiers. Only `0.2.1` resolves |
+| Stellar SDK version clash | `@sub-rosa/sdk` requires `@stellar/stellar-sdk@^15`; OFFER-HUB-API is on `14.4.3` |
+| Outside SCF scope | Sub Rosa is not a deliverable of T1, T2 or T3 of Build Award #44 |
+| Receipts do not verify chain state | Receipt verification is offline only — it checks internal consistency, not current on-chain state |
+
+So the demo installs **nothing**: no `@sub-rosa/sdk`, no `@stellar/stellar-sdk`, no change to
+`package.json` or `package-lock.json`. The sealed-round lifecycle is simulated in memory.
+
+## Structure
+
+```
+sub-rosa.constants.ts   flag, copy, links
+sub-rosa.types.ts       SealedRound, SealedProposal, RoundPhase, …
+adapter/
+  sub-rosa-adapter.ts   the seam — interface only
+  mock-adapter.ts       the only implementation today (in memory)
+mocks/
+  sealed-round.mock.ts  sample job + three fictional providers
+hooks/
+  use-sealed-round.ts   lifecycle state machine
+components/             presentational only
+```
+
+Everything lives in one folder rather than being spread across `components/`, `hooks/`, `types/`
+and `mocks/` as the repo convention would normally have it. That is deliberate: removability is
+the point of this feature, and hunting pieces across five directories would defeat it. Naming
+rules from [`docs/naming.md`](../../../docs/naming.md) are still followed, and `page.tsx` is still
+a pure orchestrator.
+
+## The honesty rules
+
+Sub Rosa's [Offer-Hub pilot doc](https://github.com/karagozemin/Sub-Rosa/blob/main/docs/pilots/OFFER_HUB_PILOT.md)
+states that sample proposals must never be presented as on-chain evidence. This page holds to
+that:
+
+- no fabricated round ID, contract ID, transaction hash, signature or receipt — those fields read
+  `Sample only` / `Not claimed`;
+- `Protocol winner: None for ReceiptOnly`, because the client's choice is application state and
+  never a protocol result;
+- a persistent `DemoBanner` above the fold, so screenshots carry their own disclaimer.
+
+Keep these if you extend the demo.
+
+## If it ever goes real
+
+Write a `live-adapter.ts` against the `SubRosaAdapter` interface and swap the argument passed to
+`useSealedRound()`. The method names already mirror the real SDK surface
+(`createSealedProposalRound`, `sealProposal` + `submitV2`, `open_reveal_v2`, `reveal_v2`). No UI
+component would change.
+
+That step means installing an unaudited dependency and signing real transactions, so it belongs in
+its own reviewed PR — not here.

--- a/src/features/sub-rosa/adapter/mock-adapter.ts
+++ b/src/features/sub-rosa/adapter/mock-adapter.ts
@@ -1,0 +1,47 @@
+import { MOCK_LATENCY_MS } from "../sub-rosa.constants";
+import { createMockSealedRound, MOCK_PROPOSAL_CONTENTS } from "../mocks/sealed-round.mock";
+import type { SealedRound } from "../sub-rosa.types";
+import type { SubRosaAdapter } from "./sub-rosa-adapter";
+
+/**
+ * In-memory implementation of `SubRosaAdapter`.
+ *
+ * No network, no localStorage, no crypto — every transition is a pure function
+ * over the round plus a small artificial delay so loading states are visible.
+ * Nothing survives a refresh, which is the point: this is a walkthrough, not a
+ * persisted round.
+ */
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const mockSubRosaAdapter: SubRosaAdapter = {
+  async createRound(): Promise<SealedRound> {
+    await delay(MOCK_LATENCY_MS);
+    return createMockSealedRound();
+  },
+
+  async reachDeadline(round: SealedRound): Promise<SealedRound> {
+    await delay(MOCK_LATENCY_MS);
+    return { ...round, phase: "deadline_reached" };
+  },
+
+  async revealProposals(round: SealedRound): Promise<SealedRound> {
+    await delay(MOCK_LATENCY_MS);
+    return {
+      ...round,
+      phase: "revealed",
+      proposals: round.proposals.map((proposal, index) => ({
+        ...proposal,
+        isRevealed: true,
+        content: MOCK_PROPOSAL_CONTENTS[index] ?? null,
+      })),
+    };
+  },
+
+  async selectProvider(round: SealedRound, proposalId: string): Promise<SealedRound> {
+    await delay(MOCK_LATENCY_MS);
+    return { ...round, phase: "provider_selected", selectedProposalId: proposalId };
+  },
+};

--- a/src/features/sub-rosa/adapter/sub-rosa-adapter.ts
+++ b/src/features/sub-rosa/adapter/sub-rosa-adapter.ts
@@ -1,0 +1,41 @@
+import type { SealedRound } from "../sub-rosa.types";
+
+/**
+ * The seam between this demo's UI and whatever drives a sealed round.
+ *
+ * Today the only implementation is `mock-adapter.ts`, which keeps everything
+ * in memory. The method names mirror the real `@sub-rosa/sdk` surface
+ * (`createSealedProposalRound`, `sealProposal` + `submitV2`, `open_reveal_v2`,
+ * `reveal_v2`) so that swapping in a live implementation later is a matter of
+ * writing one more file against this interface — no UI changes.
+ *
+ * Deliberately NOT done here: installing `@sub-rosa/sdk`. As of 0.2.2 the
+ * published package cannot be installed with npm at all (it ships
+ * `workspace:^` dependency specifiers, which npm rejects with
+ * EUNSUPPORTEDPROTOCOL), it pulls `@stellar/stellar-sdk@^15` against the v14
+ * the API is on, and Sub Rosa's own docs/LIMITATIONS.md states Core v2 has no
+ * independent funds-handling audit yet.
+ */
+export interface SubRosaAdapter {
+  /** Opens a `ReceiptOnly` round for the sample job. */
+  createRound(): Promise<SealedRound>;
+
+  /**
+   * Advances past the shared commit deadline. In a live round this is not an
+   * action anyone takes — it happens when the drand round publishes.
+   */
+  reachDeadline(round: SealedRound): Promise<SealedRound>;
+
+  /**
+   * Reveals every sealed proposal at once. Live, this is a permissionless
+   * lifecycle of `open_reveal_v2` / `reveal_v2` calls, decrypted in separate
+   * bounded transactions rather than one atomic reveal-all.
+   */
+  revealProposals(round: SealedRound): Promise<SealedRound>;
+
+  /**
+   * Records the client's choice. Application-level state: `ReceiptOnly`
+   * declares no protocol winner.
+   */
+  selectProvider(round: SealedRound, proposalId: string): Promise<SealedRound>;
+}

--- a/src/features/sub-rosa/components/BoundaryPanel.tsx
+++ b/src/features/sub-rosa/components/BoundaryPanel.tsx
@@ -1,0 +1,114 @@
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import {
+  OFFER_HUB_RESPONSIBILITIES,
+  SUB_ROSA_RESPONSIBILITIES,
+  SUBROSA_LINKS,
+  SUBROSA_TEMPLATE,
+} from "../sub-rosa.constants";
+
+interface ColumnProps {
+  title: string;
+  items: readonly string[];
+  accent: "primary" | "secondary";
+}
+
+function Column({ title, items, accent }: ColumnProps): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        "p-5 rounded-2xl bg-background",
+        "shadow-[var(--shadow-neumorphic-inset-light)]"
+      )}
+    >
+      <h4
+        className={cn(
+          "text-sm font-bold mb-3",
+          accent === "primary" ? "text-primary" : "text-secondary"
+        )}
+      >
+        {title}
+      </h4>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item} className="flex items-start gap-2 text-sm text-text-secondary">
+            <Icon
+              path={ICON_PATHS.check}
+              size="sm"
+              className={cn(
+                "shrink-0 mt-0.5 w-3.5 h-3.5",
+                accent === "primary" ? "text-primary" : "text-secondary"
+              )}
+            />
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The responsibility split, straight from the pilot doc. Worth rendering
+ * prominently: the main risk in adopting a protocol layer is quietly handing
+ * it decisions that should stay in the marketplace.
+ */
+export function BoundaryPanel(): React.JSX.Element {
+  return (
+    <Card padding="lg">
+      <h3 className="text-lg font-bold text-text-primary">Where the boundary sits</h3>
+      <p className="text-sm text-text-secondary mt-1 mb-5">
+        Sub Rosa would supply the sealed proposal layer and nothing else. OFFER HUB keeps its
+        marketplace and its selection logic.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Column title="OFFER HUB owns" items={OFFER_HUB_RESPONSIBILITIES} accent="primary" />
+        <Column title="Sub Rosa would own" items={SUB_ROSA_RESPONSIBILITIES} accent="secondary" />
+      </div>
+
+      <div className="mt-5 pt-5 border-t border-border-light">
+        <p className="text-sm text-text-secondary">
+          <span className="font-semibold text-text-primary">
+            Why {SUBROSA_TEMPLATE} and not an auction:
+          </span>{" "}
+          the cheapest proposal is not the best freelancer. {SUBROSA_TEMPLATE} seals and reveals the
+          full set with zero escrow but declares no economic winner, so the client still compares
+          experience, approach, timeline and price and makes the call. The selected provider stays
+          application-level state and never becomes a protocol result.
+        </p>
+
+        <div className="flex flex-wrap gap-4 mt-4">
+          <a
+            href={SUBROSA_LINKS.repo}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            Sub Rosa repository
+            <Icon path={ICON_PATHS.externalLink} size="sm" className="w-3.5 h-3.5" />
+          </a>
+          <a
+            href={SUBROSA_LINKS.limitations}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            Known limitations
+            <Icon path={ICON_PATHS.externalLink} size="sm" className="w-3.5 h-3.5" />
+          </a>
+          <a
+            href={SUBROSA_LINKS.docs}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+          >
+            Integration docs
+            <Icon path={ICON_PATHS.externalLink} size="sm" className="w-3.5 h-3.5" />
+          </a>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/features/sub-rosa/components/DemoBanner.tsx
+++ b/src/features/sub-rosa/components/DemoBanner.tsx
@@ -6,6 +6,10 @@ import { SUBROSA_LINKS } from "../sub-rosa.constants";
  * Permanent, unmissable notice that nothing on this page is real. It stays
  * pinned above the fold rather than tucked into a footer — the demo exists to
  * be screenshotted, and a screenshot must carry its own disclaimer.
+ *
+ * Built as a raised neumorphic surface rather than a solid colour block: the
+ * raised/sunken shadow pair only reads against the light background, so a
+ * filled panel would flatten the page.
  */
 export function DemoBanner(): React.JSX.Element {
   return (
@@ -13,19 +17,32 @@ export function DemoBanner(): React.JSX.Element {
       role="note"
       className={cn(
         "flex flex-col gap-4 p-5 mb-6 rounded-2xl sm:flex-row sm:items-center sm:justify-between",
-        "bg-secondary text-white"
+        "bg-white shadow-[var(--shadow-neumorphic-light)]"
       )}
     >
-      <div className="flex items-start gap-3">
-        <Icon path={ICON_PATHS.infoCircle} size="md" className="text-primary shrink-0 mt-0.5" />
+      <div className="flex items-start gap-4">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center shrink-0 w-10 h-10 rounded-xl",
+            "bg-background text-primary",
+            "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+          )}
+        >
+          <Icon path={ICON_PATHS.infoCircle} size="md" />
+        </span>
         <div>
-          <p className="flex flex-wrap items-center gap-2 text-sm font-semibold">
-            <span className="px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide bg-primary text-white">
+          <p className="flex flex-wrap items-center gap-2 text-sm font-semibold text-text-primary">
+            <span
+              className={cn(
+                "px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide",
+                "bg-secondary text-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+              )}
+            >
               DEMO
             </span>
             Sample data, no blockchain activity
           </p>
-          <p className="text-sm text-white/70 mt-1.5 leading-relaxed">
+          <p className="text-sm text-text-secondary mt-1.5 leading-relaxed">
             An exploration of Sub Rosa as an optional sealed-proposal layer. It is not wired to
             OFFER HUB accounts, offers, payments or escrows, and no contract ID, transaction hash
             or receipt is claimed anywhere on this page.
@@ -39,7 +56,9 @@ export function DemoBanner(): React.JSX.Element {
         className={cn(
           "inline-flex items-center justify-center gap-1.5 shrink-0 px-4 py-2.5 rounded-xl",
           "text-sm font-medium text-white bg-primary",
-          "transition-colors duration-200 hover:bg-primary-hover"
+          "shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+          "transition-shadow duration-200",
+          "active:shadow-[var(--shadow-neumorphic-inset-light)]"
         )}
       >
         Pilot doc

--- a/src/features/sub-rosa/components/DemoBanner.tsx
+++ b/src/features/sub-rosa/components/DemoBanner.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { SUBROSA_LINKS } from "../sub-rosa.constants";
+
+/**
+ * Permanent, unmissable notice that nothing on this page is real. It stays
+ * pinned above the fold rather than tucked into a footer — the demo exists to
+ * be screenshotted, and a screenshot must carry its own disclaimer.
+ */
+export function DemoBanner(): React.JSX.Element {
+  return (
+    <div
+      role="note"
+      className={cn(
+        "flex flex-col gap-4 p-5 mb-6 rounded-2xl sm:flex-row sm:items-center sm:justify-between",
+        "bg-secondary text-white"
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Icon path={ICON_PATHS.infoCircle} size="md" className="text-primary shrink-0 mt-0.5" />
+        <div>
+          <p className="flex flex-wrap items-center gap-2 text-sm font-semibold">
+            <span className="px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide bg-primary text-white">
+              DEMO
+            </span>
+            Sample data, no blockchain activity
+          </p>
+          <p className="text-sm text-white/70 mt-1.5 leading-relaxed">
+            An exploration of Sub Rosa as an optional sealed-proposal layer. It is not wired to
+            OFFER HUB accounts, offers, payments or escrows, and no contract ID, transaction hash
+            or receipt is claimed anywhere on this page.
+          </p>
+        </div>
+      </div>
+      <a
+        href={SUBROSA_LINKS.pilot}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          "inline-flex items-center justify-center gap-1.5 shrink-0 px-4 py-2.5 rounded-xl",
+          "text-sm font-medium text-white bg-primary",
+          "transition-colors duration-200 hover:bg-primary-hover"
+        )}
+      >
+        Pilot doc
+        <Icon path={ICON_PATHS.externalLink} size="sm" />
+      </a>
+    </div>
+  );
+}

--- a/src/features/sub-rosa/components/EvidencePanel.tsx
+++ b/src/features/sub-rosa/components/EvidencePanel.tsx
@@ -1,0 +1,87 @@
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { SAMPLE_ONLY, SUBROSA_TEMPLATE } from "../sub-rosa.constants";
+import type { EvidenceRow, SealedRound } from "../sub-rosa.types";
+
+interface EvidencePanelProps {
+  round: SealedRound;
+  revealedCount: number;
+  selectedProviderName: string | null;
+}
+
+/**
+ * Builds the evidence rows.
+ *
+ * Every field that would carry on-chain proof in a live round resolves to a
+ * placeholder here. That is not an oversight — Sub Rosa's own pilot doc
+ * requires that sample proposals are never presented as on-chain evidence, so
+ * this demo fabricates no round ID, contract ID, transaction hash, signature
+ * or receipt.
+ */
+function buildRows(
+  round: SealedRound,
+  revealedCount: number,
+  selectedProviderName: string | null
+): EvidenceRow[] {
+  return [
+    { label: "Partner workflow", value: "OFFER HUB" },
+    { label: "Sub Rosa mode", value: SUBROSA_TEMPLATE },
+    { label: "Proposal count", value: String(round.proposals.length) },
+    { label: "Revealed", value: `${revealedCount}/${round.proposals.length}` },
+    { label: "Selected provider", value: selectedProviderName ?? "Not selected" },
+    { label: "Round ID", value: SAMPLE_ONLY, isUnavailableInSample: true },
+    { label: "Contract ID", value: SAMPLE_ONLY, isUnavailableInSample: true },
+    { label: "Transaction hash", value: SAMPLE_ONLY, isUnavailableInSample: true },
+    { label: "Receipt", value: "Not claimed", isUnavailableInSample: true },
+    { label: "Protocol winner", value: `None for ${SUBROSA_TEMPLATE}` },
+  ];
+}
+
+export function EvidencePanel({
+  round,
+  revealedCount,
+  selectedProviderName,
+}: EvidencePanelProps): React.JSX.Element {
+  const rows = buildRows(round, revealedCount, selectedProviderName);
+
+  return (
+    <Card padding="lg">
+      <div className="flex items-center justify-between gap-3 mb-1">
+        <div className="flex items-center gap-2">
+          <Icon path={ICON_PATHS.shield} size="sm" className="text-text-secondary" />
+          <h3 className="text-sm font-bold text-text-primary">Evidence</h3>
+        </div>
+        <span className="px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide bg-secondary text-white">
+          DEMO
+        </span>
+      </div>
+      <p className="text-xs text-text-secondary mb-5">
+        The record a partner or SCF reviewer would be shown after a round.
+      </p>
+
+      <dl className="divide-y divide-border-light">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-baseline justify-between gap-4 py-2.5">
+            <dt className="text-xs text-text-secondary">{row.label}</dt>
+            <dd
+              className={cn(
+                "text-sm text-right",
+                row.isUnavailableInSample
+                  ? "text-text-secondary italic"
+                  : "font-medium text-text-primary"
+              )}
+            >
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <p className="text-xs text-text-secondary mt-5 pt-4 border-t border-border-light">
+        A live round would fill the italic rows from signed Stellar responses only. This page has
+        made no network call and holds no round state beyond this browser tab.
+      </p>
+    </Card>
+  );
+}

--- a/src/features/sub-rosa/components/EvidencePanel.tsx
+++ b/src/features/sub-rosa/components/EvidencePanel.tsx
@@ -52,7 +52,12 @@ export function EvidencePanel({
           <Icon path={ICON_PATHS.shield} size="sm" className="text-text-secondary" />
           <h3 className="text-sm font-bold text-text-primary">Evidence</h3>
         </div>
-        <span className="px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide bg-secondary text-white">
+        <span
+          className={cn(
+            "px-2 py-0.5 rounded-md text-[10px] font-bold tracking-wide",
+            "bg-secondary text-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+          )}
+        >
           DEMO
         </span>
       </div>

--- a/src/features/sub-rosa/components/JobCard.tsx
+++ b/src/features/sub-rosa/components/JobCard.tsx
@@ -47,7 +47,8 @@ export function JobCard({
         <span
           className={cn(
             "inline-flex items-center gap-2 px-3 py-1.5 rounded-full",
-            "text-xs font-semibold text-primary bg-primary/10"
+            "text-xs font-semibold text-primary bg-background",
+            "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
           )}
         >
           <Icon path={ICON_PATHS.lock} size="sm" />

--- a/src/features/sub-rosa/components/JobCard.tsx
+++ b/src/features/sub-rosa/components/JobCard.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import type { RoundPhase, SealedJob } from "../sub-rosa.types";
+
+interface JobCardProps {
+  job: SealedJob;
+  phase: RoundPhase;
+  proposalCount: number;
+  selectedProviderName: string | null;
+}
+
+const PHASE_LABELS: Record<RoundPhase, string> = {
+  collecting: "Collecting sealed proposals",
+  deadline_reached: "Deadline reached",
+  revealed: "Proposals revealed",
+  provider_selected: "Provider selected",
+};
+
+interface FactProps {
+  label: string;
+  value: string;
+}
+
+function Fact({ label, value }: FactProps): React.JSX.Element {
+  return (
+    <div>
+      <dt className="text-xs font-medium text-text-secondary uppercase tracking-wide">{label}</dt>
+      <dd className="text-sm text-text-primary mt-1">{value}</dd>
+    </div>
+  );
+}
+
+/**
+ * The job the round was opened for. This is OFFER HUB's own object — the
+ * sealed-proposals toggle is the only thing Sub Rosa would add to it.
+ */
+export function JobCard({
+  job,
+  phase,
+  proposalCount,
+  selectedProviderName,
+}: JobCardProps): React.JSX.Element {
+  return (
+    <Card padding="lg">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-5">
+        <span
+          className={cn(
+            "inline-flex items-center gap-2 px-3 py-1.5 rounded-full",
+            "text-xs font-semibold text-primary bg-primary/10"
+          )}
+        >
+          <Icon path={ICON_PATHS.lock} size="sm" />
+          Private / Sealed Proposals on
+        </span>
+        <span className="text-xs font-medium text-text-secondary">{PHASE_LABELS[phase]}</span>
+      </div>
+
+      <h2 className="text-xl font-bold text-text-primary">{job.title}</h2>
+      <p className="text-sm text-text-secondary mt-2 leading-relaxed">{job.description}</p>
+
+      <dl className="grid grid-cols-2 gap-4 mt-6 sm:grid-cols-4">
+        <Fact label="Budget" value={job.budget} />
+        <Fact label="Deadline" value={job.deadlineLabel} />
+        <Fact label="Proposals" value={String(proposalCount)} />
+        <Fact label="Selection" value={selectedProviderName ?? "Not selected"} />
+      </dl>
+
+      <p className="text-xs text-text-secondary mt-6 pt-5 border-t border-border-light">
+        Freelancer profiles, subscription visibility and job eligibility stay outside the sealed
+        round — OFFER HUB decides who may take part before any proposal is sealed.
+      </p>
+    </Card>
+  );
+}

--- a/src/features/sub-rosa/components/ProposalCard.tsx
+++ b/src/features/sub-rosa/components/ProposalCard.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import type { SealedProposal } from "../sub-rosa.types";
+
+interface ProposalCardProps {
+  proposal: SealedProposal;
+  isSelected: boolean;
+  canSelect: boolean;
+  isBusy: boolean;
+  onSelect: (proposalId: string) => void;
+}
+
+/** The fields a provider fills in, listed by name while the content is sealed. */
+const PRIVATE_FIELDS = [
+  "Provider",
+  "Proposed price",
+  "Delivery time",
+  "Approach",
+  "Experience",
+  "Milestones",
+] as const;
+
+interface DetailProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function Detail({ label, children }: DetailProps): React.JSX.Element {
+  return (
+    <div>
+      <dt className="text-xs font-medium text-text-secondary uppercase tracking-wide">{label}</dt>
+      <dd className="text-sm text-text-primary mt-1 leading-relaxed">{children}</dd>
+    </div>
+  );
+}
+
+function SealedBody(): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        "mt-4 p-4 rounded-xl",
+        "bg-background shadow-[var(--shadow-neumorphic-inset-light)]"
+      )}
+    >
+      <p className="text-xs font-medium text-text-secondary mb-3">
+        Hidden until the shared deadline
+      </p>
+      <ul className="flex flex-wrap gap-2">
+        {PRIVATE_FIELDS.map((field) => (
+          <li
+            key={field}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white text-xs text-text-secondary"
+          >
+            <Icon path={ICON_PATHS.lock} size="sm" className="w-3 h-3" />
+            {field}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function ProposalCard({
+  proposal,
+  isSelected,
+  canSelect,
+  isBusy,
+  onSelect,
+}: ProposalCardProps): React.JSX.Element {
+  const { content } = proposal;
+
+  return (
+    <Card
+      padding="md"
+      className={cn(
+        "transition-shadow duration-200",
+        isSelected && "ring-2 ring-primary"
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-bold text-text-primary">
+            {content ? content.providerName : proposal.label}
+          </h3>
+          {content ? (
+            <p className="text-xs text-text-secondary mt-0.5">{proposal.label}</p>
+          ) : null}
+        </div>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1.5 shrink-0 px-2.5 py-1 rounded-full text-xs font-medium",
+            proposal.isRevealed ? "bg-primary/10 text-primary" : "bg-secondary/10 text-secondary"
+          )}
+        >
+          <Icon
+            path={proposal.isRevealed ? ICON_PATHS.eye : ICON_PATHS.lock}
+            size="sm"
+            className="w-3 h-3"
+          />
+          {proposal.isRevealed ? "Revealed" : "Sealed"}
+        </span>
+      </div>
+
+      {content ? (
+        <>
+          <dl className="grid grid-cols-2 gap-4 mt-4">
+            <Detail label="Price">{content.price}</Detail>
+            <Detail label="Delivery">{content.timelineDays} days</Detail>
+          </dl>
+          <dl className="grid grid-cols-1 gap-4 mt-4">
+            <Detail label="Approach">{content.approach}</Detail>
+            <Detail label="Experience">{content.experience}</Detail>
+            <Detail label="Milestones">{content.milestones}</Detail>
+          </dl>
+        </>
+      ) : (
+        <SealedBody />
+      )}
+
+      <div className="mt-5">
+        {isSelected ? (
+          <span className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+            <Icon path={ICON_PATHS.check} size="sm" />
+            Selected provider
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full sm:w-auto"
+            disabled={!canSelect || isBusy}
+            onClick={() => onSelect(proposal.id)}
+          >
+            {proposal.isRevealed ? "Select provider" : "Select provider (after reveal)"}
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/features/sub-rosa/components/ProposalCard.tsx
+++ b/src/features/sub-rosa/components/ProposalCard.tsx
@@ -53,7 +53,12 @@ function SealedBody(): React.JSX.Element {
         {PRIVATE_FIELDS.map((field) => (
           <li
             key={field}
-            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white text-xs text-text-secondary"
+            className={cn(
+              "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs text-text-secondary",
+              // Raised chips inside the sunken well — the locked fields read as
+              // objects sitting in the recess rather than painted onto it.
+              "bg-white shadow-[2px_2px_4px_#d1d5db,-2px_-2px_4px_#ffffff]"
+            )}
           >
             <Icon path={ICON_PATHS.lock} size="sm" className="w-3 h-3" />
             {field}
@@ -93,7 +98,8 @@ export function ProposalCard({
         <span
           className={cn(
             "inline-flex items-center gap-1.5 shrink-0 px-2.5 py-1 rounded-full text-xs font-medium",
-            proposal.isRevealed ? "bg-primary/10 text-primary" : "bg-secondary/10 text-secondary"
+            "bg-background shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+            proposal.isRevealed ? "text-primary" : "text-secondary"
           )}
         >
           <Icon

--- a/src/features/sub-rosa/components/RoundControls.tsx
+++ b/src/features/sub-rosa/components/RoundControls.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import type { RoundPhase } from "../sub-rosa.types";
+
+interface RoundControlsProps {
+  phase: RoundPhase;
+  revealedCount: number;
+  totalCount: number;
+  isBusy: boolean;
+  onReachDeadline: () => void;
+  onReveal: () => void;
+  onReset: () => void;
+}
+
+/**
+ * Operator controls that stand in for what the protocol would do on its own.
+ * Labelled as simulations rather than actions so nobody reads a button click
+ * as a real lifecycle call.
+ */
+export function RoundControls({
+  phase,
+  revealedCount,
+  totalCount,
+  isBusy,
+  onReachDeadline,
+  onReveal,
+  onReset,
+}: RoundControlsProps): React.JSX.Element {
+  return (
+    <Card padding="lg">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon path={ICON_PATHS.settings} size="sm" className="text-text-secondary" />
+        <h3 className="text-sm font-bold text-text-primary">Round operations</h3>
+      </div>
+      <p className="text-xs text-text-secondary mb-5">
+        In a live round nobody presses these. The deadline arrives when the drand round publishes,
+        and reveal is a permissionless lifecycle any participant can finish.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={onReachDeadline}
+          disabled={isBusy || phase !== "collecting"}
+          icon={<Icon path={ICON_PATHS.clock} size="sm" />}
+          iconPosition="left"
+        >
+          Simulate deadline
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onReveal}
+          disabled={isBusy || phase !== "deadline_reached"}
+          icon={<Icon path={ICON_PATHS.eye} size="sm" />}
+          iconPosition="left"
+        >
+          Reveal proposals
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onReset}
+          disabled={isBusy}
+          icon={<Icon path={ICON_PATHS.refresh} size="sm" />}
+          iconPosition="left"
+        >
+          Reset workspace
+        </Button>
+      </div>
+
+      <div
+        className={cn(
+          "flex items-center justify-between mt-5 px-4 py-3 rounded-xl",
+          "bg-background shadow-[var(--shadow-neumorphic-inset-light)]"
+        )}
+      >
+        <span className="text-xs font-medium text-text-secondary">Visible proposals</span>
+        <span className="text-sm font-bold text-text-primary tabular-nums">
+          {revealedCount}/{totalCount}
+        </span>
+      </div>
+    </Card>
+  );
+}

--- a/src/features/sub-rosa/components/RoundTimeline.tsx
+++ b/src/features/sub-rosa/components/RoundTimeline.tsx
@@ -32,10 +32,16 @@ export function RoundTimeline({ phase }: RoundTimelineProps): React.JSX.Element 
             <span
               className={cn(
                 "inline-flex items-center gap-2 px-3 py-1.5 rounded-xl text-xs font-medium",
-                "transition-colors duration-200",
-                isCurrent && "bg-primary text-white",
-                isDone && "bg-primary/10 text-primary",
-                !isDone && !isCurrent && "bg-background text-text-secondary"
+                "transition-all duration-200",
+                // Raised for the step in progress, sunken for everything else:
+                // the elevation carries the state as much as the colour does.
+                isCurrent &&
+                  "bg-primary text-white shadow-[4px_4px_8px_#d1d5db,-4px_-4px_8px_#ffffff]",
+                isDone &&
+                  "bg-background text-primary shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]",
+                !isDone &&
+                  !isCurrent &&
+                  "bg-background text-text-secondary shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
               )}
               aria-current={isCurrent ? "step" : undefined}
             >

--- a/src/features/sub-rosa/components/RoundTimeline.tsx
+++ b/src/features/sub-rosa/components/RoundTimeline.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ROUND_STEPS } from "../sub-rosa.constants";
+import type { RoundPhase } from "../sub-rosa.types";
+
+interface RoundTimelineProps {
+  phase: RoundPhase;
+}
+
+/**
+ * How far the round has advanced. "Job created" is always behind us, so the
+ * phase maps onto the step index one past it.
+ */
+const PHASE_STEP_INDEX: Record<RoundPhase, number> = {
+  collecting: 1,
+  deadline_reached: 2,
+  revealed: 3,
+  provider_selected: 4,
+};
+
+export function RoundTimeline({ phase }: RoundTimelineProps): React.JSX.Element {
+  const currentIndex = PHASE_STEP_INDEX[phase];
+
+  return (
+    <ol className="flex flex-wrap items-center gap-x-2 gap-y-3" aria-label="Round progress">
+      {ROUND_STEPS.map((step, index) => {
+        const isDone = index < currentIndex;
+        const isCurrent = index === currentIndex;
+
+        return (
+          <li key={step} className="flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-flex items-center gap-2 px-3 py-1.5 rounded-xl text-xs font-medium",
+                "transition-colors duration-200",
+                isCurrent && "bg-primary text-white",
+                isDone && "bg-primary/10 text-primary",
+                !isDone && !isCurrent && "bg-background text-text-secondary"
+              )}
+              aria-current={isCurrent ? "step" : undefined}
+            >
+              {isDone ? (
+                <Icon path={ICON_PATHS.check} size="sm" />
+              ) : (
+                <span className="w-4 text-center tabular-nums">{index + 1}</span>
+              )}
+              {step}
+            </span>
+            {index < ROUND_STEPS.length - 1 ? (
+              <Icon
+                path={ICON_PATHS.chevronRight}
+                size="sm"
+                className="text-text-secondary/50 hidden sm:block"
+              />
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/features/sub-rosa/components/SealedProposalList.tsx
+++ b/src/features/sub-rosa/components/SealedProposalList.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { ProposalCard } from "./ProposalCard";
+import type { RoundPhase, SealedProposal } from "../sub-rosa.types";
+
+interface SealedProposalListProps {
+  proposals: SealedProposal[];
+  phase: RoundPhase;
+  selectedProposalId: string | null;
+  isBusy: boolean;
+  onSelect: (proposalId: string) => void;
+}
+
+function ListHeader({ phase, count }: { phase: RoundPhase; count: number }): React.JSX.Element {
+  const isSealed = phase === "collecting" || phase === "deadline_reached";
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+      <h2 className="text-lg font-bold text-text-primary">Proposals</h2>
+      <p className="inline-flex items-center gap-2 text-xs text-text-secondary">
+        <Icon path={isSealed ? ICON_PATHS.lock : ICON_PATHS.eye} size="sm" className="w-3.5 h-3.5" />
+        {isSealed
+          ? `${count} sealed — only the count is public before the deadline`
+          : `${count} revealed together at the shared deadline`}
+      </p>
+    </div>
+  );
+}
+
+export function SealedProposalList({
+  proposals,
+  phase,
+  selectedProposalId,
+  isBusy,
+  onSelect,
+}: SealedProposalListProps): React.JSX.Element {
+  if (proposals.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col items-center text-center py-12 px-6 rounded-2xl",
+          "bg-background shadow-[var(--shadow-neumorphic-inset-light)]"
+        )}
+      >
+        <Icon path={ICON_PATHS.document} size="xl" className="text-text-secondary mb-3" />
+        <p className="text-sm font-medium text-text-primary">No proposals yet</p>
+        <p className="text-sm text-text-secondary mt-1">
+          Sealed proposals appear here as providers commit them.
+        </p>
+      </div>
+    );
+  }
+
+  // Selection is a business decision the client makes after comparing the full
+  // set, so it only unlocks once every proposal is on the table.
+  const canSelect = phase === "revealed";
+
+  return (
+    <section>
+      <ListHeader phase={phase} count={proposals.length} />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        {proposals.map((proposal) => (
+          <ProposalCard
+            key={proposal.id}
+            proposal={proposal}
+            isSelected={proposal.id === selectedProposalId}
+            canSelect={canSelect}
+            isBusy={isBusy}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/sub-rosa/components/SubRosaDemo.tsx
+++ b/src/features/sub-rosa/components/SubRosaDemo.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/Button";
+import { Icon, ICON_PATHS } from "@/components/ui/Icon";
+import { useSealedRound } from "../hooks/use-sealed-round";
+import { SUBROSA_TEMPLATE } from "../sub-rosa.constants";
+import { BoundaryPanel } from "./BoundaryPanel";
+import { DemoBanner } from "./DemoBanner";
+import { EvidencePanel } from "./EvidencePanel";
+import { JobCard } from "./JobCard";
+import { RoundControls } from "./RoundControls";
+import { RoundTimeline } from "./RoundTimeline";
+import { SealedProposalList } from "./SealedProposalList";
+
+function DemoSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-4 animate-pulse" aria-hidden>
+      <div className="h-32 rounded-2xl bg-white shadow-[var(--shadow-neumorphic-light)]" />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="h-64 rounded-2xl bg-white shadow-[var(--shadow-neumorphic-light)] lg:col-span-2" />
+        <div className="h-64 rounded-2xl bg-white shadow-[var(--shadow-neumorphic-light)]" />
+      </div>
+    </div>
+  );
+}
+
+interface DemoErrorProps {
+  message: string;
+  onRetry: () => void;
+}
+
+function DemoError({ message, onRetry }: DemoErrorProps): React.JSX.Element {
+  return (
+    <div className="max-w-lg mx-auto text-center py-16 px-4">
+      <Icon
+        path={ICON_PATHS.alertCircle}
+        size="xl"
+        className="mx-auto text-text-secondary mb-4"
+      />
+      <h2 className="text-xl font-bold text-text-primary mb-2">Workspace unavailable</h2>
+      <p className="text-text-secondary mb-6">{message}</p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Try again
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Root of the Sub Rosa sealed-proposal walkthrough.
+ *
+ * Everything under `src/features/sub-rosa` is self-contained: no store, no
+ * service, no shared type of the product domain is touched, and the feature
+ * adds no dependency to package.json.
+ */
+export function SubRosaDemo(): React.JSX.Element {
+  const {
+    round,
+    isLoading,
+    error,
+    pendingAction,
+    revealedCount,
+    reachDeadline,
+    revealProposals,
+    selectProvider,
+    reset,
+  } = useSealedRound();
+
+  const isBusy = pendingAction !== null;
+
+  const selectedProviderName =
+    round?.proposals.find((proposal) => proposal.id === round.selectedProposalId)?.content
+      ?.providerName ?? null;
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 sm:px-6 lg:px-8">
+      <div className="max-w-6xl mx-auto">
+        <header className="mb-6">
+          <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold text-secondary bg-secondary/10">
+            <Icon path={ICON_PATHS.lock} size="sm" className="w-3.5 h-3.5" />
+            Optional sealed proposals
+          </span>
+          <h1 className="text-3xl font-bold text-text-primary mt-3">
+            Sub Rosa on OFFER HUB
+          </h1>
+          <p className="text-text-secondary mt-2 max-w-3xl leading-relaxed">
+            A walkthrough of what an optional sealed-proposal round would look like: freelancers
+            submit privately, everything is revealed together at a shared deadline, and only then
+            does the client compare and pick. Modelled on Sub Rosa&apos;s {SUBROSA_TEMPLATE}{" "}
+            template, which never takes custody of funds.
+          </p>
+        </header>
+
+        <DemoBanner />
+
+        {isLoading ? (
+          <DemoSkeleton />
+        ) : error !== null && round === null ? (
+          <DemoError message={error} onRetry={reset} />
+        ) : round === null ? null : (
+          <>
+            <div
+              className={cn(
+                "p-4 mb-6 rounded-2xl bg-white overflow-x-auto",
+                "shadow-[var(--shadow-neumorphic-light)]"
+              )}
+            >
+              <RoundTimeline phase={round.phase} />
+            </div>
+
+            {error !== null ? (
+              <div className="mb-4 p-3 rounded-xl bg-error/10 text-error text-sm" role="alert">
+                {error}
+              </div>
+            ) : null}
+
+            <div className="grid grid-cols-1 gap-4 mb-4 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <JobCard
+                  job={round.job}
+                  phase={round.phase}
+                  proposalCount={round.proposals.length}
+                  selectedProviderName={selectedProviderName}
+                />
+              </div>
+              <RoundControls
+                phase={round.phase}
+                revealedCount={revealedCount}
+                totalCount={round.proposals.length}
+                isBusy={isBusy}
+                onReachDeadline={reachDeadline}
+                onReveal={revealProposals}
+                onReset={reset}
+              />
+            </div>
+
+            <div className="mb-4">
+              <SealedProposalList
+                proposals={round.proposals}
+                phase={round.phase}
+                selectedProposalId={round.selectedProposalId}
+                isBusy={isBusy}
+                onSelect={selectProvider}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 mb-4 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <BoundaryPanel />
+              </div>
+              <EvidencePanel
+                round={round}
+                revealedCount={revealedCount}
+                selectedProviderName={selectedProviderName}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/features/sub-rosa/components/SubRosaDemo.tsx
+++ b/src/features/sub-rosa/components/SubRosaDemo.tsx
@@ -77,7 +77,13 @@ export function SubRosaDemo(): React.JSX.Element {
     <main className="min-h-screen bg-background px-4 py-10 sm:px-6 lg:px-8">
       <div className="max-w-6xl mx-auto">
         <header className="mb-6">
-          <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold text-secondary bg-secondary/10">
+          <span
+            className={cn(
+              "inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold",
+              "bg-background text-secondary",
+              "shadow-[inset_2px_2px_4px_#d1d5db,inset_-2px_-2px_4px_#ffffff]"
+            )}
+          >
             <Icon path={ICON_PATHS.lock} size="sm" className="w-3.5 h-3.5" />
             Optional sealed proposals
           </span>

--- a/src/features/sub-rosa/hooks/use-sealed-round.ts
+++ b/src/features/sub-rosa/hooks/use-sealed-round.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { mockSubRosaAdapter } from "../adapter/mock-adapter";
+import type { SubRosaAdapter } from "../adapter/sub-rosa-adapter";
+import type { SealedRound } from "../sub-rosa.types";
+
+/**
+ * Drives the sealed round through its lifecycle and owns every piece of state
+ * the demo needs. The page and its components stay presentational.
+ */
+
+type PendingAction = "deadline" | "reveal" | "select" | null;
+
+interface UseSealedRoundResult {
+  round: SealedRound | null;
+  isLoading: boolean;
+  error: string | null;
+  pendingAction: PendingAction;
+  revealedCount: number;
+  reachDeadline: () => void;
+  revealProposals: () => void;
+  selectProvider: (proposalId: string) => void;
+  reset: () => void;
+}
+
+export function useSealedRound(
+  adapter: SubRosaAdapter = mockSubRosaAdapter
+): UseSealedRoundResult {
+  const [round, setRound] = useState<SealedRound | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setRound(await adapter.createRound());
+    } catch (createError) {
+      setRound(null);
+      setError(
+        createError instanceof Error ? createError.message : "Could not open the sample round."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [adapter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  /**
+   * Every transition shares the same shape: mark the action pending, hand the
+   * current round to the adapter, swap in whatever comes back.
+   */
+  const runAction = useCallback(
+    (action: Exclude<PendingAction, null>, transition: (current: SealedRound) => Promise<SealedRound>) => {
+      if (!round || pendingAction !== null) return;
+      setPendingAction(action);
+      setError(null);
+      void (async () => {
+        try {
+          setRound(await transition(round));
+        } catch (actionError) {
+          setError(
+            actionError instanceof Error ? actionError.message : "That step could not be completed."
+          );
+        } finally {
+          setPendingAction(null);
+        }
+      })();
+    },
+    [round, pendingAction]
+  );
+
+  const reachDeadline = useCallback(() => {
+    runAction("deadline", (current) => adapter.reachDeadline(current));
+  }, [adapter, runAction]);
+
+  const revealProposals = useCallback(() => {
+    runAction("reveal", (current) => adapter.revealProposals(current));
+  }, [adapter, runAction]);
+
+  const selectProvider = useCallback(
+    (proposalId: string) => {
+      runAction("select", (current) => adapter.selectProvider(current, proposalId));
+    },
+    [adapter, runAction]
+  );
+
+  const revealedCount = round?.proposals.filter((proposal) => proposal.isRevealed).length ?? 0;
+
+  return {
+    round,
+    isLoading,
+    error,
+    pendingAction,
+    revealedCount,
+    reachDeadline,
+    revealProposals,
+    selectProvider,
+    reset: () => void load(),
+  };
+}

--- a/src/features/sub-rosa/index.ts
+++ b/src/features/sub-rosa/index.ts
@@ -1,0 +1,3 @@
+export { SubRosaDemo } from "./components/SubRosaDemo";
+export { IS_SUBROSA_DEMO_ENABLED, SUBROSA_DEMO_FLAG } from "./sub-rosa.constants";
+export type { SubRosaAdapter } from "./adapter/sub-rosa-adapter";

--- a/src/features/sub-rosa/mocks/sealed-round.mock.ts
+++ b/src/features/sub-rosa/mocks/sealed-round.mock.ts
@@ -1,0 +1,72 @@
+import type { ProposalContent, SealedJob, SealedRound } from "../sub-rosa.types";
+
+/**
+ * Sample data for the sealed-proposal demo. Obviously fictional providers —
+ * these are never presented as on-chain evidence.
+ *
+ * The job matches the one in the Sub Rosa pilot doc so the two demos line up
+ * when shown side by side.
+ */
+
+export const MOCK_SEALED_JOB: SealedJob = {
+  title: "Build a Stellar merchant analytics dashboard",
+  description:
+    "Create a dashboard for merchants to monitor Stellar payments, transaction volume and customer activity.",
+  budget: "2,000 USDC",
+  deadlineLabel: "5 minutes after the round opens",
+};
+
+/**
+ * Deliberately not ordered by price. The whole argument for `ReceiptOnly` over
+ * an auction is that the cheapest proposal is not automatically the best one —
+ * the client still has to weigh timeline, approach and track record.
+ */
+export const MOCK_PROPOSAL_CONTENTS: ProposalContent[] = [
+  {
+    providerName: "Nova Labs",
+    price: "1,850 USDC",
+    timelineDays: 21,
+    approach:
+      "Next.js dashboard reading Horizon and Stellar RPC directly, with a thin aggregation layer cached in Redis. Ships with merchant-facing CSV export.",
+    experience:
+      "Four Soroban dashboards delivered, two of them live on mainnet. Previously built payment analytics for a LATAM PSP.",
+    milestones: "Data layer → charts → merchant export → handover",
+  },
+  {
+    providerName: "StellarCraft",
+    price: "1,400 USDC",
+    timelineDays: 30,
+    approach:
+      "Reuse an in-house charting kit on top of a nightly indexer. Lower cost, but the indexer batch means figures lag real time by up to a day.",
+    experience:
+      "Two Stellar integrations, both testnet only. Strong on frontend craft, first time shipping a merchant-facing product.",
+    milestones: "Indexer → dashboard shell → charts",
+  },
+  {
+    providerName: "Orbit Studio",
+    price: "2,000 USDC",
+    timelineDays: 14,
+    approach:
+      "Streaming Stellar RPC subscriptions into a live dashboard, with alerting on payment failures and a mobile-first layout from day one.",
+    experience:
+      "Seven Stellar projects including an SCF-funded wallet. Team of three available full time for the whole window.",
+    milestones: "Streaming layer → live charts → alerts → mobile pass → QA",
+  },
+];
+
+/** The round as it looks the moment the deadline starts running. */
+export function createMockSealedRound(): SealedRound {
+  return {
+    id: "sample-round",
+    template: "ReceiptOnly",
+    phase: "collecting",
+    job: MOCK_SEALED_JOB,
+    proposals: MOCK_PROPOSAL_CONTENTS.map((_, index) => ({
+      id: `sample-proposal-${index + 1}`,
+      label: `Proposal ${String(index + 1).padStart(2, "0")}`,
+      isRevealed: false,
+      content: null,
+    })),
+    selectedProposalId: null,
+  };
+}

--- a/src/features/sub-rosa/sub-rosa.constants.ts
+++ b/src/features/sub-rosa/sub-rosa.constants.ts
@@ -1,0 +1,72 @@
+/**
+ * Configuration and copy for the Sub Rosa demo.
+ *
+ * Removing the feature means deleting `src/features/sub-rosa` and
+ * `src/app/labs` — see the README in this folder.
+ */
+
+/**
+ * The demo route 404s unless this is explicitly turned on. Off by default so
+ * production stays untouched without a code change; flip it on a preview
+ * deploy to show the page.
+ *
+ * Read as a full literal expression rather than through a helper: Next inlines
+ * `process.env.NEXT_PUBLIC_*` at build time only when it can see the static
+ * member access.
+ */
+export const IS_SUBROSA_DEMO_ENABLED = process.env.NEXT_PUBLIC_SUBROSA_DEMO === "true";
+
+export const SUBROSA_DEMO_FLAG = "NEXT_PUBLIC_SUBROSA_DEMO";
+
+/** The Sub Rosa template this demo models. `ReceiptOnly` never moves assets. */
+export const SUBROSA_TEMPLATE = "ReceiptOnly" as const;
+
+/** Artificial latency so loading states are visible while clicking through. */
+export const MOCK_LATENCY_MS = 400;
+
+export const SUBROSA_LINKS = {
+  repo: "https://github.com/karagozemin/Sub-Rosa",
+  docs: "https://sub-rosa-web.vercel.app/#/docs",
+  pilot:
+    "https://github.com/karagozemin/Sub-Rosa/blob/main/docs/pilots/OFFER_HUB_PILOT.md",
+  limitations:
+    "https://github.com/karagozemin/Sub-Rosa/blob/main/docs/LIMITATIONS.md",
+} as const;
+
+/**
+ * The split of responsibilities, taken from the "Responsibilities" section of
+ * the pilot doc. Rendered verbatim by `BoundaryPanel` so the demo can never be
+ * mistaken for Sub Rosa taking over marketplace logic.
+ */
+export const OFFER_HUB_RESPONSIBILITIES = [
+  "Marketplace discovery and fixed-price listings",
+  "Freelancer identity and profiles",
+  "Subscriptions and visibility",
+  "Eligibility and business rules",
+  "Job lifecycle and provider selection",
+  "Payment, fulfillment, and disputes",
+] as const;
+
+export const SUB_ROSA_RESPONSIBILITIES = [
+  "The sealed proposal round",
+  "Proposal confidentiality before the deadline",
+  "The drand-gated reveal lifecycle",
+  "The canonical round receipt and offline verification",
+] as const;
+
+/** The five states the timeline walks through. */
+export const ROUND_STEPS = [
+  "Job created",
+  "Sealed proposals",
+  "Deadline reached",
+  "Revealed",
+  "Provider selected",
+] as const;
+
+/**
+ * Placeholder shown wherever a live round would carry real on-chain evidence.
+ * The pilot doc is explicit that sample proposals are never presented as
+ * on-chain evidence, so no contract id, transaction hash, signature or receipt
+ * is ever fabricated here.
+ */
+export const SAMPLE_ONLY = "Sample only";

--- a/src/features/sub-rosa/sub-rosa.types.ts
+++ b/src/features/sub-rosa/sub-rosa.types.ts
@@ -1,0 +1,74 @@
+/**
+ * Domain types for the Sub Rosa sealed-proposal demo.
+ *
+ * These mirror the vocabulary of the `ReceiptOnly` template documented in
+ * https://github.com/karagozemin/Sub-Rosa/blob/main/docs/pilots/OFFER_HUB_PILOT.md
+ * so that a future real integration can reuse the same shapes. Nothing here
+ * touches OFFER HUB's own offer/application types on purpose — the demo must
+ * stay severable from the product domain.
+ */
+
+/**
+ * Lifecycle of a sealed round. In the real protocol the move from
+ * `collecting` to `deadline_reached` is gated by a drand round publishing,
+ * and `revealed` is reached by permissionless reveal transactions. Here both
+ * are driven by the operator buttons in `RoundControls`.
+ */
+export type RoundPhase =
+  | "collecting"
+  | "deadline_reached"
+  | "revealed"
+  | "provider_selected";
+
+/** The job a round is opened for. Owned by OFFER HUB, not by Sub Rosa. */
+export interface SealedJob {
+  title: string;
+  description: string;
+  budget: string;
+  deadlineLabel: string;
+}
+
+/** Everything a provider writes into a proposal before it is sealed. */
+export interface ProposalContent {
+  providerName: string;
+  price: string;
+  timelineDays: number;
+  approach: string;
+  experience: string;
+  milestones: string;
+}
+
+/**
+ * A proposal as everyone else sees it before the shared deadline: a label, a
+ * sealed status, and nothing else. The demo deliberately exposes no
+ * commitment hash — a fabricated one would read as cryptographic evidence.
+ */
+export interface SealedProposal {
+  id: string;
+  label: string;
+  isRevealed: boolean;
+  /** Populated only once the round reaches `revealed`. */
+  content: ProposalContent | null;
+}
+
+export interface SealedRound {
+  /** Always a sample identifier. A real round would carry a numeric on-chain id. */
+  id: string;
+  template: "ReceiptOnly";
+  phase: RoundPhase;
+  job: SealedJob;
+  proposals: SealedProposal[];
+  /**
+   * Application-level state. In `ReceiptOnly` the protocol declares no winner,
+   * so this never maps onto a receipt's `winner` field.
+   */
+  selectedProposalId: string | null;
+}
+
+/** One row of the evidence panel. */
+export interface EvidenceRow {
+  label: string;
+  value: string;
+  /** Marks a field that would only carry a real value in a live round. */
+  isUnavailableInSample?: boolean;
+}


### PR DESCRIPTION
# 📝 Pull Request

## 🔧 Title:

- feat(labs): removable Sub Rosa sealed-proposals demo

## 🛠️ Issue

- Closes #343

## 📚 Description

A third party (Sub Rosa) proposed OFFER HUB adopt their sealed-proposal layer: freelancers submit encrypted proposals, everything is revealed together at a shared deadline, and only then does the client compare and pick. Their repo already ships [a pilot doc written for us](https://github.com/karagozemin/Sub-Rosa/blob/main/docs/pilots/OFFER_HUB_PILOT.md).

This PR adds a page to **evaluate that idea visually** — nothing more. It is not an adoption, and it is built so it can be deleted in one command.

**Merging this changes nothing in production.** `NEXT_PUBLIC_SUBROSA_DEMO` is off by default, so the route calls `notFound()` and behaves as if it does not exist. It only becomes reachable if the variable is set to `true` **and the app is rebuilt** (`NEXT_PUBLIC_*` is inlined at build time).

### Why it is isolated rather than integrated

| Concern | Evidence |
| --- | --- |
| No funds-handling audit | Sub Rosa's own [`docs/LIMITATIONS.md`](https://github.com/karagozemin/Sub-Rosa/blob/main/docs/LIMITATIONS.md): *"Core v2 … has no independent funds-handling audit yet"* |
| Latest SDK uninstallable with npm | `npm i @sub-rosa/sdk@0.2.2` fails with `EUNSUPPORTEDPROTOCOL` — it publishes `workspace:^` dependency specifiers. Only `0.2.1` resolves |
| Stellar SDK version clash | `@sub-rosa/sdk` requires `@stellar/stellar-sdk@^15`; OFFER-HUB-API is on `14.4.3` |
| Outside SCF scope | Not a deliverable of T1, T2 or T3 of Build Award #44 |
| Receipts do not verify chain state | Receipt verification is offline only |

So the demo installs **nothing** and the sealed-round lifecycle is simulated in memory.

### How to remove it

```bash
rm -rf src/features/sub-rosa src/app/labs
```

Plus the commented block in `.env.example`. No lockfile change to revert, no store or service to unwire, no migration.

### How to see it

```bash
echo 'NEXT_PUBLIC_SUBROSA_DEMO=true' > .env.local && npm run dev
# http://localhost:3000/labs/sub-rosa
```

Then: **Simulate deadline** → **Reveal proposals** → **Select provider**.

## ✅ Changes applied

Seven atomic commits:

1. `feat(labs)` — sealed-round domain types and sample data
2. `feat(labs)` — the adapter seam and its in-memory implementation
3. `feat(labs)` — the demo components
4. `feat(labs)` — the `/labs/sub-rosa` route behind the feature flag
5. `docs(labs)` — enable/remove documentation
6. `style(labs)` — neumorphic elevation on every demo surface
7. `docs` — require neumorphic elevation on every frontend surface (`CLAUDE.md`)

**New files**, all under two folders:

```
src/features/sub-rosa/    types, constants, adapter, mock, hook, 8 components, README
src/app/labs/             route + layout (noindex, nofollow)
```

**Shared files modified: two**, neither of them product code.

- `.env.example` — a commented block for the flag
- `CLAUDE.md` — a new "Neumorphism is not optional" section (see below)

Untouched: `package.json`, `package-lock.json`, `AppSidebar`, `mode-store`, every route under `/app`, every existing service and hook.

### Neumorphism rule (commit 7)

The first pass at this page had the right palette but painted most surfaces flat, so it read as detached from the site. Commit 6 fixes the page; commit 7 fixes the cause.

`CLAUDE.md` now states that every surface must carry elevation — raised or sunken — and that a flat coloured block is a bug, not a style choice. It adds a table mapping each kind of surface (card, well, badge, active item, pressed state) to its treatment, the rule that a solid filled panel is never a large container (the shadow pair only reads against the light `#F1F3F7` background), guidance to prefer the CSS variables so dark mode keeps working, and a note on nesting elevation.

This part is independent of the demo and survives its removal — happy to split it into its own PR if reviewers prefer.

### Design notes

- Route sits **outside** the authenticated app shell and is **absent from navigation** — direct URL only, so it never surfaces to the 103 existing users.
- Uses the existing design system: `Card`, `Button`, `Icon`, navy `secondary`, teal `primary`, neumorphic shadows.
- Everything lives in one folder rather than being spread across `components/`, `hooks/`, `types/` and `mocks/` as the repo convention would normally have it. That is a deliberate trade for removability — hunting pieces across five directories would defeat the point. Naming rules from `docs/naming.md` are still followed and `page.tsx` is still a pure orchestrator.
- The adapter interface mirrors the real SDK surface (`createSealedProposalRound`, `sealProposal` + `submitV2`, `open_reveal_v2`, `reveal_v2`), so going live later means writing one `live-adapter.ts` and changing no component. That step installs an unaudited dependency and signs real transactions, so it belongs in its own reviewed PR.

### Honesty rules the page holds to

Sub Rosa's pilot doc requires that sample proposals are never presented as on-chain evidence. Accordingly:

- no fabricated round ID, contract ID, transaction hash, signature or receipt — those fields read `Sample only` / `Not claimed`;
- `Protocol winner: None for ReceiptOnly`, because the client's choice is application state, never a protocol result;
- a persistent DEMO banner above the fold, so screenshots carry their own disclaimer.

## 🔍 Evidence/Media (screenshots/videos)

**Verification**

| Check | Result |
| --- | --- |
| `git diff upstream/main -- package.json package-lock.json` | empty |
| Shared files modified | `.env.example`, `CLAUDE.md` — no product code |
| `npx tsc --noEmit` | clean |
| `npx eslint src/features/sub-rosa src/app/labs` | 0 problems |
| `npm run build` | passes, `/labs/sub-rosa` prerendered static |
| Flag **off** | `/labs/sub-rosa` → **404**; `/app/dashboard`, `/marketplace`, `/login` → 200 |

**Lifecycle walkthrough** (driven in headless Chrome over CDP):

| State | Card titles | Revealed | Selected | Fabricated Stellar IDs |
| --- | --- | --- | --- | --- |
| collecting | `Proposal 01/02/03` | 0/3 | Not selected | 0 |
| deadline reached | `Proposal 01/02/03` | 0/3 | Not selected | 0 |
| revealed | `Nova Labs`, `StellarCraft`, `Orbit Studio` | 3/3 | Not selected | 0 |
| provider selected | provider names | 3/3 | `StellarCraft` | 0 |

Provider names are absent from the DOM until reveal. Selecting the second card propagates consistently to all three surfaces (evidence panel, job card, selection ring). In all four states `Round ID` / `Contract ID` / `Transaction hash` = `Sample only`, `Receipt` = `Not claimed`, `Protocol winner` = `None for ReceiptOnly`.

Screenshots of the sealed and revealed states to be attached.
